### PR TITLE
content: expand trivia questions for 5 topics to ≥10 each

### DIFF
--- a/assets/questions/topics/agatha_christie.json
+++ b/assets/questions/topics/agatha_christie.json
@@ -102,5 +102,93 @@
     "articleUrl": "https://en.m.wikipedia.org/wiki/And_Then_There_Were_None",
     "topicId": "agatha_christie",
     "difficulty": "medium"
+  },
+  {
+    "id": "ac_006",
+    "question": "What is Miss Marple's first name?",
+    "correctAnswers": ["Jane"],
+    "wrongAnswers": ["Margaret", "Dorothy", "Agatha", "Helen"],
+    "funFact": "Miss Marple's full name is Jane Marple. Christie rarely used the first name in the stories, preferring to keep her as the familiar 'Miss Marple', which contributed to her air of genteel mystery.",
+    "articleTitle": "Miss Marple",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Miss_Marple",
+    "topicId": "agatha_christie",
+    "difficulty": "easy"
+  },
+  {
+    "id": "ac_007",
+    "question": "In which English village does Miss Marple live?",
+    "correctAnswers": ["St. Mary Mead"],
+    "wrongAnswers": ["Little Pidding", "Chipping Norton", "Nether Wallop", "Much Benham"],
+    "funFact": "St. Mary Mead is a fictional village in the south of England. Christie used the quiet setting to great irony — the seemingly peaceful village is repeatedly touched by murder, giving Miss Marple ample practice in reading human nature.",
+    "articleTitle": "Miss Marple",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Miss_Marple",
+    "topicId": "agatha_christie",
+    "difficulty": "easy"
+  },
+  {
+    "id": "ac_008",
+    "question": "In which short story did Miss Marple make her first appearance?",
+    "correctAnswers": ["The Tuesday Night Club"],
+    "wrongAnswers": ["The Murder at the Vicarage", "A Caribbean Mystery", "The Body in the Library", "Sleeping Murder"],
+    "funFact": "'The Tuesday Night Club' was first published in the Royal Magazine in December 1927. It introduced Miss Marple as part of a group of friends who challenge each other to solve real crimes from memory — and she invariably wins.",
+    "articleTitle": "Miss Marple",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Miss_Marple",
+    "topicId": "agatha_christie",
+    "difficulty": "medium"
+  },
+  {
+    "id": "ac_009",
+    "question": "How many full-length novels feature Miss Marple as the central detective?",
+    "correctAnswers": ["12"],
+    "wrongAnswers": ["8", "10", "15", "20"],
+    "funFact": "Christie wrote 12 Miss Marple novels in total, from 'The Murder at the Vicarage' (1930) to 'Sleeping Murder', which was written during World War II but published posthumously in 1976.",
+    "articleTitle": "Miss Marple",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Miss_Marple",
+    "topicId": "agatha_christie",
+    "difficulty": "medium"
+  },
+  {
+    "id": "ac_010",
+    "question": "Which actress was personally chosen by Agatha Christie herself to play Miss Marple on television?",
+    "correctAnswers": ["Joan Hickson"],
+    "wrongAnswers": ["Margaret Rutherford", "Angela Lansbury", "Helen Hayes", "Geraldine McEwan"],
+    "funFact": "Joan Hickson was personally chosen by Agatha Christie after Christie saw Hickson in a 1946 stage play. Christie wrote her a note saying she hoped Hickson would one day play Miss Marple — a wish fulfilled nearly 40 years later.",
+    "articleTitle": "Miss Marple",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Miss_Marple",
+    "topicId": "agatha_christie",
+    "difficulty": "medium"
+  },
+  {
+    "id": "ac_011",
+    "question": "Which Miss Marple novel was written during World War II but only published after Agatha Christie's death?",
+    "correctAnswers": ["Sleeping Murder"],
+    "wrongAnswers": ["A Caribbean Mystery", "At Bertram's Hotel", "Nemesis", "The Mirror Crack'd from Side to Side"],
+    "funFact": "Christie wrote both 'Sleeping Murder' and 'Curtain' (Poirot's last case) during the Blitz as a precaution, sealing them away in a bank vault. 'Sleeping Murder' was released in 1976 as a farewell gift to readers.",
+    "articleTitle": "Miss Marple",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Miss_Marple",
+    "topicId": "agatha_christie",
+    "difficulty": "hard"
+  },
+  {
+    "id": "ac_012",
+    "question": "Miss Marple's method of solving crimes relies on comparing suspects to people she has known in which setting?",
+    "correctAnswers": ["Her village of St. Mary Mead"],
+    "wrongAnswers": ["Her years working as a nurse", "Her time spent travelling abroad", "Her extensive reading of detective fiction", "Her work as a magistrate"],
+    "funFact": "Christie gave Miss Marple the insight that human nature is universal — a dishonest butcher's boy in a village is essentially the same type as a murderer in a country house. This 'village parallel' method makes her appear dotty while being razor sharp.",
+    "articleTitle": "Miss Marple",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Miss_Marple",
+    "topicId": "agatha_christie",
+    "difficulty": "hard"
+  },
+  {
+    "id": "ac_013",
+    "question": "In which 1930 novel did Miss Marple make her first full-length book appearance?",
+    "correctAnswers": ["The Murder at the Vicarage"],
+    "wrongAnswers": ["The Mysterious Affair at Styles", "Murder on the Orient Express", "The ABC Murders", "Death on the Nile"],
+    "funFact": "'The Murder at the Vicarage' is narrated by the local vicar, Reverend Leonard Clement, giving an outsider's perspective on Miss Marple's seemingly harmless but relentlessly perceptive investigations into village life.",
+    "articleTitle": "Miss Marple",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Miss_Marple",
+    "topicId": "agatha_christie",
+    "difficulty": "hard"
   }
 ]

--- a/assets/questions/topics/anatomy.json
+++ b/assets/questions/topics/anatomy.json
@@ -2,18 +2,8 @@
   {
     "id": "anat_001",
     "question": "How many bones does the adult human body contain?",
-    "correctAnswers": [
-      "206"
-    ],
-    "wrongAnswers": [
-      "180",
-      "230",
-      "300",
-      "150",
-      "250",
-      "196",
-      "212"
-    ],
+    "correctAnswers": ["206"],
+    "wrongAnswers": ["180", "230", "300", "150", "250", "196", "212"],
     "funFact": "Babies are born with around 270–300 bones. Many of these fuse together during childhood, resulting in the adult count of 206.",
     "articleTitle": "Human skeleton",
     "articleUrl": "https://en.m.wikipedia.org/wiki/Human_skeleton",
@@ -23,17 +13,8 @@
   {
     "id": "anat_002",
     "question": "Which is the largest organ in the human body?",
-    "correctAnswers": [
-      "The skin"
-    ],
-    "wrongAnswers": [
-      "The liver",
-      "The small intestine",
-      "The brain",
-      "The lungs",
-      "The stomach",
-      "The large intestine"
-    ],
+    "correctAnswers": ["The skin"],
+    "wrongAnswers": ["The liver", "The small intestine", "The brain", "The lungs", "The stomach", "The large intestine"],
     "funFact": "The skin accounts for about 15% of body weight and, when spread flat, covers roughly 2 square metres in an average adult.",
     "articleTitle": "Human skin",
     "articleUrl": "https://en.m.wikipedia.org/wiki/Human_skin",
@@ -43,17 +24,8 @@
   {
     "id": "anat_003",
     "question": "The human heart has how many chambers?",
-    "correctAnswers": [
-      "4"
-    ],
-    "wrongAnswers": [
-      "2",
-      "3",
-      "6",
-      "5",
-      "8",
-      "1"
-    ],
+    "correctAnswers": ["4"],
+    "wrongAnswers": ["2", "3", "6", "5", "8", "1"],
     "funFact": "The heart beats about 100,000 times per day, pumping roughly 7,500 litres of blood through approximately 96,000 km of blood vessels.",
     "articleTitle": "Heart",
     "articleUrl": "https://en.m.wikipedia.org/wiki/Heart#Chambers",
@@ -63,21 +35,89 @@
   {
     "id": "anat_004",
     "question": "Which part of the brain is primarily responsible for balance and coordination?",
-    "correctAnswers": [
-      "The cerebellum"
-    ],
-    "wrongAnswers": [
-      "The cerebrum",
-      "The brain stem",
-      "The thalamus",
-      "The hippocampus",
-      "The amygdala",
-      "The prefrontal cortex"
-    ],
+    "correctAnswers": ["The cerebellum"],
+    "wrongAnswers": ["The cerebrum", "The brain stem", "The thalamus", "The hippocampus", "The amygdala", "The prefrontal cortex"],
     "funFact": "Although the cerebellum accounts for only 10% of the brain's volume, it contains more than 50% of the total number of neurons.",
     "articleTitle": "Cerebellum",
     "articleUrl": "https://en.m.wikipedia.org/wiki/Cerebellum",
     "topicId": "anatomy",
     "difficulty": "medium"
+  },
+  {
+    "id": "anat_005",
+    "question": "Which organ produces insulin to regulate blood sugar levels?",
+    "correctAnswers": ["Pancreas"],
+    "wrongAnswers": ["Liver", "Kidney", "Spleen", "Adrenal gland"],
+    "funFact": "The pancreas is both an endocrine gland (releasing hormones like insulin directly into the blood) and an exocrine gland (secreting digestive enzymes into the small intestine). It weighs only about 80 grams yet plays a critical role in metabolism.",
+    "articleTitle": "Pancreas",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Pancreas",
+    "topicId": "anatomy",
+    "difficulty": "easy"
+  },
+  {
+    "id": "anat_006",
+    "question": "What is the longest bone in the human body?",
+    "correctAnswers": ["Femur"],
+    "wrongAnswers": ["Tibia", "Humerus", "Fibula", "Radius"],
+    "funFact": "The femur, or thigh bone, is the strongest bone in the body and can withstand forces several times greater than body weight. It makes up roughly a quarter of a person's total height.",
+    "articleTitle": "Femur",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Femur",
+    "topicId": "anatomy",
+    "difficulty": "easy"
+  },
+  {
+    "id": "anat_007",
+    "question": "Which type of blood vessel carries oxygenated blood away from the heart?",
+    "correctAnswers": ["Artery"],
+    "wrongAnswers": ["Vein", "Capillary", "Venule", "Lymphatic vessel"],
+    "funFact": "The pulmonary artery is the one notable exception — it carries deoxygenated blood from the heart to the lungs. Arteries have thick, muscular walls to withstand the high pressure of blood pumped directly from the heart.",
+    "articleTitle": "Artery",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Artery",
+    "topicId": "anatomy",
+    "difficulty": "medium"
+  },
+  {
+    "id": "anat_008",
+    "question": "What is the basic structural and functional unit of the nervous system?",
+    "correctAnswers": ["Neuron"],
+    "wrongAnswers": ["Nephron", "Sarcomere", "Alveolus", "Glial cell"],
+    "funFact": "The human brain contains approximately 86 billion neurons, each capable of forming thousands of synaptic connections. A single nerve impulse travels at speeds up to 120 metres per second.",
+    "articleTitle": "Neuron",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Neuron",
+    "topicId": "anatomy",
+    "difficulty": "medium"
+  },
+  {
+    "id": "anat_009",
+    "question": "Which valve separates the left ventricle from the aorta?",
+    "correctAnswers": ["Aortic valve"],
+    "wrongAnswers": ["Mitral valve", "Tricuspid valve", "Pulmonary valve", "Bicuspid valve"],
+    "funFact": "The aortic valve opens approximately 100,000 times per day as the heart beats. Its three leaflets are shaped like half-moons, earning it the alternate name 'semilunar valve'.",
+    "articleTitle": "Aortic valve",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Aortic_valve",
+    "topicId": "anatomy",
+    "difficulty": "medium"
+  },
+  {
+    "id": "anat_010",
+    "question": "The functional unit of the kidney responsible for filtering blood is called the:",
+    "correctAnswers": ["Nephron"],
+    "wrongAnswers": ["Glomerulus", "Loop of Henle", "Renal pelvis", "Bowman's capsule"],
+    "funFact": "Each human kidney contains roughly one million nephrons. If all the tubules from both kidneys were stretched end to end, they would extend about 80 kilometres.",
+    "articleTitle": "Nephron",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Nephron",
+    "topicId": "anatomy",
+    "difficulty": "hard"
+  },
+  {
+    "id": "anat_011",
+    "question": "Which connective tissue protein is the most abundant in the human body, making up about one-third of total protein mass?",
+    "correctAnswers": ["Collagen"],
+    "wrongAnswers": ["Elastin", "Keratin", "Actin", "Fibronectin"],
+    "funFact": "There are at least 28 distinct types of collagen in the human body. Gram for gram, type I collagen is stronger than steel wire.",
+    "articleTitle": "Collagen",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Collagen",
+    "topicId": "anatomy",
+    "difficulty": "hard"
   }
 ]

--- a/assets/questions/topics/french_literature.json
+++ b/assets/questions/topics/french_literature.json
@@ -99,5 +99,145 @@
     "articleUrl": "https://en.m.wikipedia.org/wiki/Existentialism",
     "topicId": "french_literature",
     "difficulty": "easy"
+  },
+  {
+    "id": "fl_006",
+    "question": "Which Molière comedy centres on a miser so obsessed with his money that he drives away his own children?",
+    "correctAnswers": [
+      "The Miser (L'Avare)"
+    ],
+    "wrongAnswers": [
+      "Tartuffe",
+      "The Misanthrope",
+      "The Bourgeois Gentleman",
+      "The Imaginary Invalid",
+      "The Learned Ladies",
+      "Don Juan"
+    ],
+    "funFact": "Molière based The Miser on the ancient Roman comedy Aulularia by Plautus, yet set it in 17th-century Paris, making the greed feel timeless.",
+    "articleTitle": "The Miser (Molière)",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/The_Miser_(Moli%C3%A8re)",
+    "topicId": "french_literature",
+    "difficulty": "easy"
+  },
+  {
+    "id": "fl_007",
+    "question": "Victor Hugo's 1831 novel set in medieval Paris and centred on the Cathedral of Notre-Dame is commonly known in English as what?",
+    "correctAnswers": [
+      "The Hunchback of Notre-Dame"
+    ],
+    "wrongAnswers": [
+      "Notre-Dame de Paris",
+      "The Bells of Paris",
+      "Quasimodo",
+      "The Cathedral",
+      "The Gargoyle of Paris",
+      "The Poet and the Cathedral"
+    ],
+    "funFact": "Hugo wrote the novel partly to draw public attention to the neglected state of Gothic architecture in France; the book's popularity directly inspired restoration work on the real Notre-Dame cathedral.",
+    "articleTitle": "The Hunchback of Notre-Dame",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/The_Hunchback_of_Notre-Dame",
+    "topicId": "french_literature",
+    "difficulty": "easy"
+  },
+  {
+    "id": "fl_008",
+    "question": "Marcel Proust's seven-volume novel cycle \"In Search of Lost Time\" begins with which volume?",
+    "correctAnswers": [
+      "Swann's Way"
+    ],
+    "wrongAnswers": [
+      "Within a Budding Grove",
+      "The Guermantes Way",
+      "Time Regained",
+      "Sodom and Gomorrah",
+      "The Captive",
+      "The Fugitive"
+    ],
+    "funFact": "Swann's Way was initially rejected by several publishers, including Gallimard, so Proust paid for its publication himself in 1913 — Gallimard later signed him and published the rest of the cycle.",
+    "articleTitle": "Swann's Way",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Swann%27s_Way",
+    "topicId": "french_literature",
+    "difficulty": "medium"
+  },
+  {
+    "id": "fl_009",
+    "question": "Émile Zola's 1898 open letter defending Alfred Dreyfus, published on the front page of a newspaper, is famous under what title?",
+    "correctAnswers": [
+      "J'Accuse…!"
+    ],
+    "wrongAnswers": [
+      "La Vérité",
+      "Le Manifeste",
+      "L'Humanité",
+      "Je Défends",
+      "La Justice",
+      "L'Affaire"
+    ],
+    "funFact": "Zola's letter was addressed directly to the French President and accused the army of anti-semitism and obstruction of justice; it resulted in Zola being convicted of libel and fleeing to England for nearly a year.",
+    "articleTitle": "J'accuse...!",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/J%27accuse...!",
+    "topicId": "french_literature",
+    "difficulty": "medium"
+  },
+  {
+    "id": "fl_010",
+    "question": "The French literary movement known as the Nouveau Roman (New Novel) rejected traditional narrative conventions. Which author is most closely identified as its founder?",
+    "correctAnswers": [
+      "Alain Robbe-Grillet"
+    ],
+    "wrongAnswers": [
+      "Michel Butor",
+      "Nathalie Sarraute",
+      "Claude Simon",
+      "Marguerite Duras",
+      "Raymond Queneau",
+      "Georges Perec"
+    ],
+    "funFact": "Robbe-Grillet's 1957 manifesto \"For a New Novel\" argued that fiction should abandon psychology and plot in favour of precise, objective description of surfaces — an idea he called chosisme (thing-ism).",
+    "articleTitle": "French New Novel",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/French_New_Novel",
+    "topicId": "french_literature",
+    "difficulty": "hard"
+  },
+  {
+    "id": "fl_011",
+    "question": "Stendhal's 1830 novel \"The Red and the Black\" takes its title from colours thought to represent what two career paths available to an ambitious young man in Restoration France?",
+    "correctAnswers": [
+      "The military and the Church"
+    ],
+    "wrongAnswers": [
+      "Politics and the law",
+      "Trade and academia",
+      "Nobility and the bourgeoisie",
+      "The Church and commerce",
+      "The army and the press",
+      "Revolution and monarchy"
+    ],
+    "funFact": "Stendhal based his protagonist Julien Sorel on a real criminal case he read about in a newspaper; he wrote the entire novel in just 52 days.",
+    "articleTitle": "The Red and the Black",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/The_Red_and_the_Black",
+    "topicId": "french_literature",
+    "difficulty": "hard"
+  },
+  {
+    "id": "fl_012",
+    "question": "Which French Romantic poet, known for collections such as \"Les Fleurs du mal,\" was himself prosecuted for obscenity upon the work's 1857 publication?",
+    "correctAnswers": [
+      "Charles Baudelaire"
+    ],
+    "wrongAnswers": [
+      "Paul Verlaine",
+      "Arthur Rimbaud",
+      "Stéphane Mallarmé",
+      "Gérard de Nerval",
+      "Alfred de Musset",
+      "Alphonse de Lamartine"
+    ],
+    "funFact": "Six poems were ordered removed from Les Fleurs du mal after the trial; they were not legally published in France until 1949 — nearly a century after Baudelaire wrote them.",
+    "articleTitle": "Charles Baudelaire",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Charles_Baudelaire",
+    "topicId": "french_literature",
+    "difficulty": "hard"
   }
 ]

--- a/assets/questions/topics/lily_mayne.json
+++ b/assets/questions/topics/lily_mayne.json
@@ -61,5 +61,153 @@
     "articleUrl": "https://en.m.wikipedia.org/wiki/Paranormal_romance",
     "topicId": "lily_mayne",
     "difficulty": "medium"
+  },
+  {
+    "id": "lm_004",
+    "question": "What is the publishing model used by most indie romance authors, where the author retains full rights and uploads directly to retail platforms?",
+    "correctAnswers": [
+      "Self-publishing"
+    ],
+    "wrongAnswers": [
+      "Traditional publishing",
+      "Vanity publishing",
+      "Hybrid publishing",
+      "Academic publishing"
+    ],
+    "funFact": "Self-publishing platforms like Amazon KDP and Smashwords have allowed indie romance authors to reach global audiences without a literary agent or publishing house.",
+    "articleTitle": "Self-publishing",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Self-publishing",
+    "topicId": "lily_mayne",
+    "difficulty": "easy"
+  },
+  {
+    "id": "lm_005",
+    "question": "Which Amazon subscription service is particularly important to indie romance authors' income, paying royalties based on pages read?",
+    "correctAnswers": [
+      "Kindle Unlimited"
+    ],
+    "wrongAnswers": [
+      "Audible Plus",
+      "Amazon First Reads",
+      "Prime Reading",
+      "Kindle Vella"
+    ],
+    "funFact": "Kindle Unlimited (KU) is a major revenue stream for indie romance authors; enrolling in KU requires exclusivity with Amazon, which has divided the indie publishing community.",
+    "articleTitle": "Self-publishing",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Self-publishing",
+    "topicId": "lily_mayne",
+    "difficulty": "easy"
+  },
+  {
+    "id": "lm_006",
+    "question": "In MM romance and queer fiction, what term describes a romantic pairing where one partner is human and the other is a fantastical non-human creature?",
+    "correctAnswers": [
+      "Monster romance"
+    ],
+    "wrongAnswers": [
+      "Dark romance",
+      "Fated mates",
+      "Omegaverse",
+      "Reverse harem",
+      "Slow burn"
+    ],
+    "funFact": "Monster romance surged in popularity in the early 2020s, with indie authors like Lily Mayne helping pioneer queer monster romance as a distinct subgenre.",
+    "articleTitle": "Paranormal romance",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Paranormal_romance",
+    "topicId": "lily_mayne",
+    "difficulty": "medium"
+  },
+  {
+    "id": "lm_007",
+    "question": "What trope, common in paranormal and fantasy romance, describes two characters who are cosmically destined to be together, often with a supernatural bond?",
+    "correctAnswers": [
+      "Fated mates"
+    ],
+    "wrongAnswers": [
+      "Enemies to lovers",
+      "Fake dating",
+      "Second chance romance",
+      "Grumpy/sunshine",
+      "Forced proximity"
+    ],
+    "funFact": "The fated mates trope has roots in folklore and mythology and remains one of the most searched-for tropes on romance reader communities like Goodreads and BookTok.",
+    "articleTitle": "Romance novel",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Romance_novel",
+    "topicId": "lily_mayne",
+    "difficulty": "medium"
+  },
+  {
+    "id": "lm_008",
+    "question": "What subgenre sets a romance story in a speculative future society, often featuring oppressive governments or post-apocalyptic worlds, and has seen growth in queer fiction?",
+    "correctAnswers": [
+      "Dystopian romance"
+    ],
+    "wrongAnswers": [
+      "Steampunk romance",
+      "Cyberpunk romance",
+      "Space opera romance",
+      "Solarpunk romance",
+      "Biopunk romance"
+    ],
+    "funFact": "Queer dystopian fiction gained wide readership following the success of novels like 'The Handmaid's Tale', inspiring indie authors to explore LGBTQ+ identities within oppressive future worlds.",
+    "articleTitle": "Romance novel",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Romance_novel",
+    "topicId": "lily_mayne",
+    "difficulty": "medium"
+  },
+  {
+    "id": "lm_009",
+    "question": "In romance publishing, what does the acronym 'HEA' stand for, representing the genre's core narrative expectation?",
+    "correctAnswers": [
+      "Happily Ever After"
+    ],
+    "wrongAnswers": [
+      "Heartbreaking Emotional Arc",
+      "Hero's Emotional Awakening",
+      "Happy Ending Always",
+      "Hopeful Ending Achieved"
+    ],
+    "funFact": "The Romance Writers of America defines a romance novel by two key elements: a central love story and an emotionally satisfying HEA or HFN (Happy For Now) ending.",
+    "articleTitle": "Romance novel",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Romance_novel",
+    "topicId": "lily_mayne",
+    "difficulty": "hard"
+  },
+  {
+    "id": "lm_010",
+    "question": "What social media phenomenon, centred on TikTok's book community, dramatically accelerated the commercial success of indie and queer romance authors in the early 2020s?",
+    "correctAnswers": [
+      "BookTok"
+    ],
+    "wrongAnswers": [
+      "Bookstagram",
+      "BookTube",
+      "Bookworm Reddit",
+      "GoodreadsGate",
+      "LitTok"
+    ],
+    "funFact": "BookTok is credited with reviving sales of backlist titles and launching debut indie authors to bestseller status; by 2023 it had driven billions of views for romance and queer fiction content.",
+    "articleTitle": "Gay literature",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Gay_literature",
+    "topicId": "lily_mayne",
+    "difficulty": "hard"
+  },
+  {
+    "id": "lm_011",
+    "question": "In the context of indie romance publishing, what is a 'series bible', and why is it especially important for authors writing long dark fantasy or monster romance series?",
+    "correctAnswers": [
+      "A reference document tracking world-building rules, character details, and continuity across books in a series"
+    ],
+    "wrongAnswers": [
+      "A contract between the author and a self-publishing platform",
+      "A marketing plan outlining how to launch each book in a series",
+      "A reader guide included at the back of each novel",
+      "A shared universe agreement between multiple indie authors"
+    ],
+    "funFact": "Long-running indie fantasy romance series can span ten or more books; a series bible helps authors maintain consistency in lore, magic systems, and character arcs across hundreds of thousands of words.",
+    "articleTitle": "Self-publishing",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Self-publishing",
+    "topicId": "lily_mayne",
+    "difficulty": "hard"
   }
 ]

--- a/assets/questions/topics/medicine.json
+++ b/assets/questions/topics/medicine.json
@@ -2,17 +2,8 @@
   {
     "id": "med_001",
     "question": "What is the most widely prescribed class of drugs for treating bacterial infections?",
-    "correctAnswers": [
-      "Antibiotics"
-    ],
-    "wrongAnswers": [
-      "Antivirals",
-      "Antifungals",
-      "Analgesics",
-      "Corticosteroids",
-      "Antihistamines",
-      "Beta-blockers"
-    ],
+    "correctAnswers": ["Antibiotics"],
+    "wrongAnswers": ["Antivirals", "Antifungals", "Analgesics", "Corticosteroids", "Antihistamines", "Beta-blockers"],
     "funFact": "Since Alexander Fleming discovered penicillin in 1928, antibiotics have saved an estimated 200 million lives.",
     "articleTitle": "Antibiotic",
     "articleUrl": "https://en.m.wikipedia.org/wiki/Antibiotic",
@@ -22,17 +13,8 @@
   {
     "id": "med_002",
     "question": "Which organ is responsible for filtering about 200 litres of blood per day in the human body?",
-    "correctAnswers": [
-      "The kidneys"
-    ],
-    "wrongAnswers": [
-      "The liver",
-      "The spleen",
-      "The heart",
-      "The lungs",
-      "The pancreas",
-      "The lymph nodes"
-    ],
+    "correctAnswers": ["The kidneys"],
+    "wrongAnswers": ["The liver", "The spleen", "The heart", "The lungs", "The pancreas", "The lymph nodes"],
     "funFact": "Each kidney contains about one million tiny filtering units called nephrons. You can survive with just one healthy kidney.",
     "articleTitle": "Kidney",
     "articleUrl": "https://en.m.wikipedia.org/wiki/Kidney",
@@ -42,19 +24,99 @@
   {
     "id": "med_003",
     "question": "What is the term for a study that tracks a group of people over time to observe health outcomes?",
-    "correctAnswers": [
-      "Cohort study"
-    ],
-    "wrongAnswers": [
-      "Case-control study",
-      "Randomised controlled trial",
-      "Cross-sectional study",
-      "Meta-analysis",
-      "Systematic review"
-    ],
+    "correctAnswers": ["Cohort study"],
+    "wrongAnswers": ["Case-control study", "Randomised controlled trial", "Cross-sectional study", "Meta-analysis", "Systematic review"],
     "funFact": "The Framingham Heart Study, started in 1948, is one of the longest-running cohort studies and first identified smoking as a major risk factor for heart disease.",
     "articleTitle": "Cohort study",
     "articleUrl": "https://en.m.wikipedia.org/wiki/Cohort_study",
+    "topicId": "medicine",
+    "difficulty": "hard"
+  },
+  {
+    "id": "med_004",
+    "question": "Which vaccine, developed in 1796 by Edward Jenner, was the first to be created using a scientific approach?",
+    "correctAnswers": ["Smallpox vaccine"],
+    "wrongAnswers": ["Polio vaccine", "Rabies vaccine", "Cholera vaccine", "Typhoid vaccine"],
+    "funFact": "Jenner noticed that milkmaids who caught cowpox seemed immune to smallpox. The word 'vaccine' itself comes from 'vacca', Latin for cow.",
+    "articleTitle": "Smallpox vaccine",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Smallpox_vaccine",
+    "topicId": "medicine",
+    "difficulty": "easy"
+  },
+  {
+    "id": "med_005",
+    "question": "What name is given to the surgical procedure in which a blocked coronary artery is bypassed using a graft vessel?",
+    "correctAnswers": ["Coronary artery bypass graft"],
+    "wrongAnswers": ["Angioplasty", "Endarterectomy", "Valve replacement", "Aortic dissection repair"],
+    "funFact": "During a bypass, surgeons often harvest the saphenous vein from the patient's own leg to use as the graft, rerouting blood flow around the blockage entirely.",
+    "articleTitle": "Coronary artery bypass surgery",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Coronary_artery_bypass_surgery",
+    "topicId": "medicine",
+    "difficulty": "easy"
+  },
+  {
+    "id": "med_006",
+    "question": "What is the medical term for the surgical removal of the appendix?",
+    "correctAnswers": ["Appendectomy"],
+    "wrongAnswers": ["Cholecystectomy", "Colectomy", "Laparotomy", "Splenectomy"],
+    "funFact": "Appendectomy is one of the most commonly performed emergency surgeries worldwide; laparoscopic techniques now allow surgeons to remove the appendix through incisions less than a centimetre wide.",
+    "articleTitle": "Appendectomy",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Appendectomy",
+    "topicId": "medicine",
+    "difficulty": "easy"
+  },
+  {
+    "id": "med_007",
+    "question": "Which 19th-century physician is credited with introducing antiseptic surgical technique, dramatically reducing post-operative mortality?",
+    "correctAnswers": ["Joseph Lister"],
+    "wrongAnswers": ["Robert Koch", "Louis Pasteur", "Ignaz Semmelweis", "Florence Nightingale"],
+    "funFact": "Lister used carbolic acid (phenol) to sterilise surgical instruments and wound dressings; death rates from amputation in his ward fell from roughly 46% to under 15% within a few years.",
+    "articleTitle": "Joseph Lister",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Joseph_Lister",
+    "topicId": "medicine",
+    "difficulty": "medium"
+  },
+  {
+    "id": "med_008",
+    "question": "What diagnostic tool, first described in 1895, uses electromagnetic radiation to image dense internal structures such as bone?",
+    "correctAnswers": ["X-ray"],
+    "wrongAnswers": ["MRI scan", "Ultrasound", "CT scan", "PET scan"],
+    "funFact": "Wilhelm Röntgen discovered X-rays accidentally while experimenting with cathode rays. The very first medical X-ray image was of his wife's hand, clearly showing her bones and wedding ring.",
+    "articleTitle": "X-ray",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/X-ray",
+    "topicId": "medicine",
+    "difficulty": "easy"
+  },
+  {
+    "id": "med_009",
+    "question": "Which blood-typing system, discovered in 1901 by Karl Landsteiner, is most critical to match before performing a blood transfusion?",
+    "correctAnswers": ["ABO blood group system"],
+    "wrongAnswers": ["Rh factor system", "Kell system", "Duffy antigen system", "Lewis antigen system"],
+    "funFact": "Before Landsteiner's discovery, blood transfusions were often fatal. Understanding ABO compatibility earned him the Nobel Prize in Physiology or Medicine in 1930.",
+    "articleTitle": "ABO blood group system",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/ABO_blood_group_system",
+    "topicId": "medicine",
+    "difficulty": "medium"
+  },
+  {
+    "id": "med_010",
+    "question": "What term describes a clinical trial where neither the patient nor the clinician knows who is receiving the active treatment or a placebo?",
+    "correctAnswers": ["Double-blind trial"],
+    "wrongAnswers": ["Open-label study", "Single-blind trial", "Crossover study", "Case-control study"],
+    "funFact": "Double-blinding is considered the gold standard for drug trials because it eliminates both patient expectation bias and unconscious clinician bias, producing far more reliable efficacy data.",
+    "articleTitle": "Blinded experiment",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Blinded_experiment",
+    "topicId": "medicine",
+    "difficulty": "medium"
+  },
+  {
+    "id": "med_011",
+    "question": "Which rare but serious condition, caused by Clostridium botulinum toxin, blocks acetylcholine release at neuromuscular junctions and can cause life-threatening paralysis?",
+    "correctAnswers": ["Botulism"],
+    "wrongAnswers": ["Tetanus", "Guillain-Barré syndrome", "Myasthenia gravis", "Lambert-Eaton syndrome"],
+    "funFact": "The same toxin responsible for fatal botulism is commercially refined into Botox, used in tiny doses to temporarily paralyse facial muscles for cosmetic and therapeutic purposes.",
+    "articleTitle": "Botulism",
+    "articleUrl": "https://en.m.wikipedia.org/wiki/Botulism",
     "topicId": "medicine",
     "difficulty": "hard"
   }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Expands 5 topic question banks from their previous low counts to ≥10 questions each, as part of the larger goal of reaching ≥10 questions per topic across all 35 topics.

| Topic | Before | After |
|-------|--------|-------|
| `agatha_christie` | 5 | 13 |
| `lily_mayne` | 3 | 11 |
| `french_literature` | 5 | 12 |
| `medicine` | 3 | 11 |
| `anatomy` | 4 | 11 |

### New content highlights
- **agatha_christie** — Miss Marple questions: her village, first appearance, Joan Hickson casting, posthumous novel
- **lily_mayne** — MM/queer romance genre: self-publishing, monster romance, BookTok, HEA convention
- **french_literature** — Molière, Hugo, Zola's J'Accuse, French New Novel, Baudelaire
- **medicine** — Jenner's smallpox vaccine, Lister antisepsis, Röntgen X-ray, ABO blood groups, double-blind trials
- **anatomy** — Pancreas, femur, neurons, nephron, collagen

All questions follow the established schema (≥4 wrong answers, easy/medium/hard distribution, mobile Wikipedia URLs).

## Test plan
- [ ] `flutter analyze --fatal-infos` passes (no new Dart code changed)
- [ ] JSON files are valid (no parse errors)
- [ ] Question IDs are unique within each topic file

https://claude.ai/code/session_0164cB8wZMuAbfzvQXY9ouuq
EOF
)