### PR TITLE
feat: endless game mode (#39)

### DIFF
--- a/lib/features/gameplay/domain/models/quiz_config.dart
+++ b/lib/features/gameplay/domain/models/quiz_config.dart
@@ -1,11 +1,15 @@
+enum GameMode { standard, endless }
+
 /// Configuration for a single game session.
 class QuizConfig {
   final Set<String> selectedTopicIds;
-  final int questionCount; // 5, 10, or 20
+  final int questionCount; // 5, 10, or 20 — ignored in endless mode
+  final GameMode gameMode;
 
   const QuizConfig({
     required this.selectedTopicIds,
     required this.questionCount,
+    this.gameMode = GameMode.standard,
   });
 
   static const List<int> validCounts = [5, 10, 20];
@@ -13,10 +17,12 @@ class QuizConfig {
   QuizConfig copyWith({
     Set<String>? selectedTopicIds,
     int? questionCount,
+    GameMode? gameMode,
   }) {
     return QuizConfig(
       selectedTopicIds: selectedTopicIds ?? this.selectedTopicIds,
       questionCount: questionCount ?? this.questionCount,
+      gameMode: gameMode ?? this.gameMode,
     );
   }
 }

--- a/lib/features/gameplay/presentation/providers/game_state_provider.dart
+++ b/lib/features/gameplay/presentation/providers/game_state_provider.dart
@@ -11,10 +11,14 @@ class GameStateNotifier extends Notifier<GameState?> {
   Future<void> startGame(QuizConfig config) async {
     // Load only the selected topics — avoids pulling all 10K questions into RAM.
     final pool = await loadQuestionsForTopics(config.selectedTopicIds);
+    // Endless mode: use all available questions; standard: respect questionCount.
+    final count = config.gameMode == GameMode.endless
+        ? pool.length
+        : config.questionCount;
     final questions = selectQuestionsFrom(
       pool,
       topicIds: config.selectedTopicIds,
-      count: config.questionCount,
+      count: count,
     );
     state = GameState.initial(questions: questions, config: config);
   }

--- a/lib/features/start/presentation/screens/topic_picker_screen.dart
+++ b/lib/features/start/presentation/screens/topic_picker_screen.dart
@@ -21,6 +21,7 @@ class TopicPickerScreen extends ConsumerStatefulWidget {
 class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
   late Set<String> _selected;
   int _questionCount = 10;
+  GameMode _gameMode = GameMode.standard;
 
   @override
   void initState() {
@@ -28,9 +29,12 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
     final config = ref.read(quizConfigProvider);
     _selected = Set.from(config.selectedTopicIds);
     _questionCount = config.questionCount;
+    _gameMode = config.gameMode;
   }
 
-  bool get _canStart => _selected.isNotEmpty;
+  bool get _canStart =>
+      _selected.isNotEmpty &&
+      (_gameMode == GameMode.endless ? _availableQuestions > 0 : true);
 
   int get _availableQuestions {
     return ref.watch(questionsProvider).maybeWhen(
@@ -80,6 +84,7 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
     final config = QuizConfig(
       selectedTopicIds: Set.from(_selected),
       questionCount: _questionCount,
+      gameMode: _gameMode,
     );
     ref.read(quizConfigProvider.notifier).state = config;
     await ref.read(gameStateProvider.notifier).startGame(config);
@@ -134,8 +139,10 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
           _BottomBar(
             questionCount: _questionCount,
             availableQuestions: _availableQuestions,
+            gameMode: _gameMode,
             canStart: _canStart,
             onCountChanged: (c) => setState(() => _questionCount = c),
+            onModeChanged: (m) => setState(() => _gameMode = m),
             onStart: _startGame,
           ),
         ],
@@ -350,22 +357,36 @@ class _CategoryTile extends StatelessWidget {
 class _BottomBar extends StatelessWidget {
   final int questionCount;
   final int availableQuestions;
+  final GameMode gameMode;
   final bool canStart;
   final void Function(int) onCountChanged;
+  final void Function(GameMode) onModeChanged;
   final VoidCallback onStart;
 
   const _BottomBar({
     required this.questionCount,
     required this.availableQuestions,
+    required this.gameMode,
     required this.canStart,
     required this.onCountChanged,
+    required this.onModeChanged,
     required this.onStart,
   });
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    final tooFew = availableQuestions < questionCount;
+    final isEndless = gameMode == GameMode.endless;
+    final tooFew = !isEndless && availableQuestions < questionCount;
+
+    String buttonLabel;
+    if (!canStart) {
+      buttonLabel = 'Select at least one topic';
+    } else if (isEndless) {
+      buttonLabel = 'Start — all $availableQuestions questions';
+    } else {
+      buttonLabel = 'Start — $questionCount questions';
+    }
 
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
@@ -376,63 +397,81 @@ class _BottomBar extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          // Mode toggle
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Text('Questions: ',
-                  style: textTheme.labelMedium
-                      ?.copyWith(color: AppColors.textLight)),
+              _ModeChip(
+                label: 'Standard',
+                active: !isEndless,
+                onTap: () => onModeChanged(GameMode.standard),
+              ),
               const SizedBox(width: 8),
-              ...[5, 10, 20].map((n) {
-                final active = n == questionCount;
-                return Padding(
-                  padding: const EdgeInsets.only(right: 6),
-                  child: GestureDetector(
-                    onTap: () => onCountChanged(n),
-                    child: Container(
-                      width: 44,
-                      height: 36,
-                      alignment: Alignment.center,
-                      decoration: BoxDecoration(
-                        color: active
-                            ? AppColors.torchAmber
-                            : AppColors.stone,
-                        borderRadius: BorderRadius.circular(6),
-                        border: Border.all(
-                            color: active
-                                ? AppColors.torchAmber
-                                : AppColors.stoneMid),
-                      ),
-                      child: Text(
-                        '$n',
-                        style: TextStyle(
-                          color: active
-                              ? AppColors.textDark
-                              : AppColors.textLight,
-                          fontWeight: FontWeight.bold,
+              _ModeChip(
+                label: '∞ Endless',
+                active: isEndless,
+                onTap: () => onModeChanged(GameMode.endless),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+
+          // Question count (hidden in endless mode)
+          if (!isEndless)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('Questions: ',
+                    style: textTheme.labelMedium
+                        ?.copyWith(color: AppColors.textLight)),
+                const SizedBox(width: 8),
+                ...[5, 10, 20].map((n) {
+                  final active = n == questionCount;
+                  return Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: GestureDetector(
+                      onTap: () => onCountChanged(n),
+                      child: Container(
+                        width: 44,
+                        height: 36,
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          color: active ? AppColors.torchAmber : AppColors.stone,
+                          borderRadius: BorderRadius.circular(6),
+                          border: Border.all(
+                            color:
+                                active ? AppColors.torchAmber : AppColors.stoneMid,
+                          ),
+                        ),
+                        child: Text(
+                          '$n',
+                          style: TextStyle(
+                            color:
+                                active ? AppColors.textDark : AppColors.textLight,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                );
-              }),
-            ],
-          ),
+                  );
+                }),
+              ],
+            ),
+
           if (tooFew && canStart)
             Padding(
               padding: const EdgeInsets.only(top: 6),
               child: Text(
                 'Only $availableQuestions questions in selected topics.',
-                style: textTheme.bodySmall
-                    ?.copyWith(color: AppColors.dangerRed),
+                style:
+                    textTheme.bodySmall?.copyWith(color: AppColors.dangerRed),
               ),
             ),
           const SizedBox(height: 12),
           SizedBox(
             width: double.infinity,
             child: ElevatedButton(
-              onPressed:
-                  canStart && !tooFew ? onStart : null,
+              onPressed: canStart && !tooFew ? onStart : null,
               style: ElevatedButton.styleFrom(
                 backgroundColor: AppColors.torchAmber,
                 foregroundColor: AppColors.textDark,
@@ -441,15 +480,53 @@ class _BottomBar extends StatelessWidget {
                     borderRadius: BorderRadius.circular(6)),
               ),
               child: Text(
-                canStart
-                    ? 'Start — $questionCount questions'
-                    : 'Select at least one topic',
+                buttonLabel,
                 style: textTheme.labelLarge
                     ?.copyWith(color: AppColors.textDark),
               ),
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _ModeChip extends StatelessWidget {
+  final String label;
+  final bool active;
+  final VoidCallback onTap;
+
+  const _ModeChip({
+    required this.label,
+    required this.active,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        decoration: BoxDecoration(
+          color: active
+              ? AppColors.torchAmber.withValues(alpha: 0.2)
+              : AppColors.stoneDark,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: active ? AppColors.torchAmber : AppColors.stoneMid,
+            width: 1.5,
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: active ? AppColors.torchAmber : AppColors.stoneMid,
+            fontWeight: active ? FontWeight.w700 : FontWeight.normal,
+            fontSize: 13,
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
Closes #39

Adds an **endless/marathon game mode** that exhausts all available questions in the selected topic(s) in a single session, rather than stopping at the 5/10/20 cap.

## Changes

- **`quiz_config.dart`** — new `GameMode` enum (`standard`, `endless`); `QuizConfig` gains a `gameMode` field (defaults to `standard`)
- **`game_state_provider.dart`** — `startGame` passes `pool.length` as the question count when endless mode is active, so all shuffled questions are dealt
- **`topic_picker_screen.dart`** — mode toggle chips (`Standard` / `∞ Endless`) added above the question-count selector; count row hides in endless mode; start button label shows total available question count

Existing standard-mode behaviour is unchanged.

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes
- [ ] Manual: Open topic picker → select one topic → tap **∞ Endless** chip → count selector disappears, button reads "Start — all N questions" → start game → play through all questions without the game ending early
- [ ] Manual: Switch back to **Standard** → count selector reappears, existing behaviour intact
- [ ] Manual: In endless mode, losing all 3 lives still triggers game-over correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)