### PR TITLE
feat: fix UI text overflow and action button state (#6 #37 #41)

### DIFF
--- a/lib/features/gameplay/presentation/widgets/answer_button.dart
+++ b/lib/features/gameplay/presentation/widgets/answer_button.dart
@@ -85,8 +85,6 @@ class AnswerButton extends StatelessWidget {
                 child: Text(
                   text,
                   style: textTheme.labelMedium?.copyWith(fontSize: 13),
-                  maxLines: 3,
-                  overflow: TextOverflow.ellipsis,
                 ),
               ),
               if (state == AnswerState.correct)

--- a/lib/features/start/presentation/screens/topic_picker_screen.dart
+++ b/lib/features/start/presentation/screens/topic_picker_screen.dart
@@ -102,19 +102,39 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
         ),
         actions: [
           IconButton(
-            icon: const Icon(Icons.bar_chart, color: AppColors.stoneMid),
+            icon: const Icon(Icons.bar_chart, color: AppColors.textLight),
             tooltip: 'Question Bank Stats',
             onPressed: () => context.push('/stats'),
           ),
           TextButton(
             onPressed: _selectAll,
-            child: const Text('All',
-                style: TextStyle(color: AppColors.torchAmber)),
+            style: TextButton.styleFrom(
+              minimumSize: Size.zero,
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+            ),
+            child: Text(
+              'All',
+              style: TextStyle(
+                color: allTopicIds.every(_selected.contains)
+                    ? AppColors.torchAmber
+                    : AppColors.stoneMid,
+              ),
+            ),
           ),
           TextButton(
             onPressed: _clearAll,
-            child: const Text('None',
-                style: TextStyle(color: AppColors.stoneMid)),
+            style: TextButton.styleFrom(
+              minimumSize: Size.zero,
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+            ),
+            child: Text(
+              'None',
+              style: TextStyle(
+                color: _selected.isEmpty
+                    ? AppColors.torchAmber
+                    : AppColors.stoneMid,
+              ),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
Closes #6
Closes #37
Closes #41

Addresses all three open UI/UX issues in a single pass:

- **#6 — Long answers cut off**: Removed `maxLines: 3` and `overflow: TextOverflow.ellipsis` from `AnswerButton` so answer text always wraps fully and is never hidden from the player.
- **#37 — Stats icon and None button grayed out / All always orange**: The bar chart stats icon now uses `AppColors.textLight` to look interactive. The "All" and "None" `TextButton` actions now reflect actual selection state — "All" highlights in `torchAmber` only when every topic is selected; "None" highlights in `torchAmber` only when nothing is selected.
- **#41 — Heading cut off**: Reduced horizontal padding on the "All" / "None" `TextButton` actions so the AppBar title has sufficient space to render in full.

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes
- [ ] Manual: open topic picker → "Choose Topics" heading renders fully
- [ ] Manual: tap "All" → button turns amber; tap "None" → "All" returns to gray, "None" turns amber
- [ ] Manual: question bank stats icon (bar chart) is clearly visible and tappable
- [ ] Manual: start a game with a long answer option → full text wraps without being cut off