### PR TITLE
feat: fair question selection, difficulty bias & visual cue (#44)

### DIFF
--- a/ai/tasks/fair-question-selection/plan.md
+++ b/ai/tasks/fair-question-selection/plan.md
@@ -1,0 +1,166 @@
+# Plan: Fair Question Selection + Difficulty Bias (Issue #44)
+
+## Context
+When a player selects topics with very different question counts, the current flat-pool
+shuffle causes the larger topic to dominate — all questions can come from one topic.
+This plan fixes that with a round-robin interleaved selection algorithm that gives each
+topic an equal expected contribution. It also adds a 1–5 difficulty bias scale so players
+can tune how hard their questions are, plus a visual difficulty badge on each question card.
+
+---
+
+## Root Cause
+
+`selectQuestionsFrom` in `question_bank.dart` merges all topic questions into one list,
+shuffles, and takes the first N. Each question has equal probability `1/total`, so a
+25-question topic is ~8× more likely to fill a slot than a 3-question topic. Difficulty
+is ignored entirely.
+
+---
+
+## Feature 1 — Round-Robin Topic Sampling (fairness fix)
+
+1. Group loaded questions by topic into independent buckets.
+2. Apply weighted shuffle within each bucket (see Feature 2 — same step).
+3. Shuffle the topic list itself (randomizes which topic fills round-1 slots).
+4. Cycle through topics picking one question per topic per round until `count` reached or all buckets exhausted.
+5. Final `shuffle()` on selected list — breaks visible interleaving pattern.
+6. Map each `Question` → `QuizQuestion` via `toQuizQuestion()`.
+
+**Properties:**
+- Each topic fills at most `ceil(count / numTopics)` slots per pass
+- No hard minimums — a topic that runs dry is skipped
+- Endless mode (`count = pool.length`): round-robin completes all rounds, selecting everything
+- Pure function — easy to unit test
+
+---
+
+## Feature 2 — Difficulty Bias Scale (1–5)
+
+Add `difficultyBias: int` (default 3) to `QuizConfig`.
+
+### Weight table
+
+| difficultyBias | easy | medium | hard | Player experience |
+|---------------|------|--------|------|-----------------|
+| 1 | 5 | 2 | 0 | Almost all easy, no hard |
+| 2 | 3 | 2 | 1 | Mostly easy |
+| 3 | 1 | 1 | 1 | Balanced (default) |
+| 4 | 1 | 2 | 3 | Mostly hard |
+| 5 | 0 | 2 | 5 | Almost all hard, no easy |
+
+### Implementation: weighted shuffle within each topic bucket
+
+```dart
+List<Question> _weightedShuffle(List<Question> bucket, int bias, Random rng) {
+  if (bias == 3) return bucket..shuffle(rng); // uniform — plain shuffle
+  final expanded = bucket
+      .expand((q) => List.filled(_difficultyWeight(q, bias), q))
+      .toList()..shuffle(rng);
+  final seen = <String>{};
+  return [for (final q in expanded) if (seen.add(q.id)) q];
+}
+```
+
+Each topic bucket is weighted-shuffled before the round-robin loop, so high-weight
+questions appear earlier in their bucket and are more likely to be picked in early rounds.
+
+---
+
+## Feature 3 — Visual Difficulty Cue on Question Card
+
+### Emoji + colour mapping
+
+| Difficulty | Emoji | Colour | Token |
+|------------|-------|--------|-------|
+| easy | 🕯️ | `#FFD700` | `AppColors.torchGold` |
+| medium | 🔥 | `#FF8C00` | `AppColors.torchAmber` |
+| hard | ⚔️ | `#C0392B` | `AppColors.dangerRed` |
+
+### Badge design
+
+Pill-shaped chip in the **bottom-left of the question card**, below the question text.
+Background: colour at 15% opacity. Border: colour at 45% opacity. Matches existing book-icon style.
+
+### Difficulty selector in `_BottomBar` (topic picker)
+
+Five tappable chips (1–5) with `🕯️ Easier` ← → `⚔️ Harder` labels.
+Active chip fills with the corresponding difficulty colour.
+Chips sit between the question-count row and the Start button.
+
+---
+
+## Variety Opportunities (all layers — updated)
+
+| Layer | Status | Notes |
+|-------|--------|-------|
+| Topic sampling | **Fix in this task** | Round-robin replaces flat pool |
+| Question ordering | **Fixed as side-effect** | Final shuffle + interleaved selection |
+| Topic order in each round | **Fixed as side-effect** | Topic list shuffled before cycling |
+| Difficulty weighting | **New in this task** | `difficultyBias` 1–5 controls easy/hard mix |
+| Answer options (correct pick, wrong picks, button positions) | Already working | `toQuizQuestion()` randomizes independently |
+
+---
+
+## Order of Operations
+
+1. **`quiz_config.dart`** — add `difficultyBias` field (int, default 3)
+2. **`question_bank.dart`** — rewrite `selectQuestionsFrom`:
+   - Add `difficultyBias` parameter
+   - Add `_difficultyWeight()` helper
+   - Add `_weightedShuffle()` helper
+   - Implement round-robin loop
+3. **`game_state_provider.dart`** — pass `config.difficultyBias` into `selectQuestionsFrom`
+4. **`question.dart`** — add `difficultyDisplay` getter to `QuizQuestion`
+5. **`question_card.dart`** — add `_DifficultyBadge` widget; update `QuestionCard.build`
+6. **`topic_picker_screen.dart`** — add `_difficultyBias` state; update `_BottomBar` with chips row; pass value through `_startGame` into `QuizConfig`
+7. **`question_bank_test.dart`** — write/update unit tests
+8. Run `flutter analyze --fatal-infos` and `flutter test`
+9. Commit
+
+---
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `lib/features/gameplay/domain/models/quiz_config.dart` | Add `difficultyBias` field + copyWith |
+| `lib/features/gameplay/data/question_bank.dart` | Rewrite `selectQuestionsFrom` with round-robin + weighted shuffle |
+| `lib/features/gameplay/presentation/providers/game_state_provider.dart` | Pass `config.difficultyBias` to `selectQuestionsFrom` |
+| `lib/features/gameplay/domain/models/question.dart` | Add `difficultyDisplay` getter to `QuizQuestion` |
+| `lib/features/gameplay/presentation/widgets/question_card.dart` | Add `_DifficultyBadge`; update `QuestionCard` layout |
+| `lib/features/start/presentation/screens/topic_picker_screen.dart` | Add difficulty chips to `_BottomBar`; wire state |
+| `test/question_bank_test.dart` | Create with fairness, weighting, and edge-case tests |
+
+---
+
+## Verification
+
+```bash
+# Static analysis
+flutter analyze --fatal-infos
+
+# Unit tests
+flutter test test/question_bank_test.dart --reporter expanded
+
+# Manual checks:
+# 1. Select Crocheting + West African History, bias=3, 5 questions
+#    → Both topics should appear across multiple playthroughs
+# 2. Set bias=1 → questions should feel noticeably easier
+# 3. Set bias=5 → questions should feel noticeably harder
+# 4. Each question card shows a coloured emoji badge (🕯️/🔥/⚔️)
+# 5. Difficulty chips in topic picker highlight the selected value with the correct colour
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Single topic selected | All questions from that topic, weighted-shuffled |
+| count > total questions | All questions returned (endless mode) |
+| Topic file missing | Empty bucket, skipped silently |
+| Topic has only easy questions, bias=5 | Weight=0 for easy, weight=2 for medium — no medium questions either → topic skipped in weighted shuffle → filled by other topics |
+| bias=3 | Uniform weights → plain shuffle → identical to old algorithm (but topic-fair) |
+| All topics same size | Identical fairness to flat shuffle, just interleaved |

--- a/ai/tasks/fair-question-selection/proposal/01-selection-algorithms.md
+++ b/ai/tasks/fair-question-selection/proposal/01-selection-algorithms.md
@@ -1,0 +1,139 @@
+# Proposal 01: Selection Algorithm Options
+
+## Goal
+Each selected topic should have an equal expected contribution to the final question set,
+regardless of how many questions that topic has. No hard minimums — just equal probability.
+
+---
+
+## Algorithm A — Current (broken): Flat Pool Shuffle
+
+```dart
+pool.shuffle();
+pool.take(count);
+```
+
+**Probability per slot:** `topicSize / totalQuestions`
+**Result:** Large topics dominate. Crocheting (3q) vs WAH (25q) → WAH is 8× more likely per slot.
+**Verdict:** ❌ Discard.
+
+---
+
+## Algorithm B — Round-Robin Interleaved (RECOMMENDED)
+
+**Concept:** Shuffle within each topic independently, then cycle through topics picking one
+question at a time until the count is reached or all topics are exhausted.
+
+```dart
+List<QuizQuestion> selectQuestionsFrom(
+  List<Question> allQuestions, {
+  required Set<String> topicIds,
+  required int count,
+  Random? rng,
+}) {
+  final random = rng ?? Random();
+
+  // Group by topic, shuffle each bucket independently.
+  final buckets = <String, List<Question>>{};
+  for (final q in allQuestions) {
+    if (topicIds.contains(q.topicId)) {
+      (buckets[q.topicId] ??= []).add(q);
+    }
+  }
+  for (final bucket in buckets.values) {
+    bucket.shuffle(random);
+  }
+
+  // Round-robin: cycle through topics, pick one per round.
+  final topicList = buckets.keys.toList()..shuffle(random); // randomise topic order too
+  final selected = <Question>[];
+  int round = 0;
+  while (selected.length < count) {
+    bool anyAdded = false;
+    for (final topicId in topicList) {
+      if (selected.length >= count) break;
+      final bucket = buckets[topicId]!;
+      if (round < bucket.length) {
+        selected.add(bucket[round]);
+        anyAdded = true;
+      }
+    }
+    if (!anyAdded) break; // all buckets exhausted
+    round++;
+  }
+
+  // Shuffle final selection so topic interleaving is not obvious.
+  selected.shuffle(random);
+  return selected.map((q) => q.toQuizQuestion(random)).toList();
+}
+```
+
+**Properties:**
+- Each topic contributes at most `ceil(count / numTopics)` questions per pass
+- Small topics (3q) and large topics (40q) are equally likely to fill round-1 slots
+- If a topic runs dry before `count` is reached, remaining slots are filled by topics with surplus
+- No hard minimum: a topic can legitimately provide 0 questions if it runs dry and others fill up
+- The final shuffle breaks the interleaved pattern → order appears fully random to the player
+
+**Expected topic representation for 5 questions, 2 topics (crocheting=3, WAH=25):**
+- Round 1: 1 crocheting, 1 WAH (2 questions)
+- Round 2: 1 crocheting, 1 WAH (4 questions)
+- Round 3: 1 crocheting, 1 WAH → stop at 5 → 3 crocheting, 2 WAH (or 2/3 depending on final shuffle position)
+- On average: near-equal representation regardless of topic size
+
+**Verdict:** ✅ Recommended. Simple, fair, handles depletion gracefully, testable.
+
+---
+
+## Algorithm C — Probability-Weighted Sampling
+
+**Concept:** Assign each question a weight of `1/topicSize`. Sample without replacement
+using these weights. Each topic has equal expected total weight.
+
+```
+weight(q) = 1.0 / topicSize(q.topicId)
+```
+
+**Implementation:** Weighted reservoir sampling (Algorithm A-Res or Efraimidis-Spirakis).
+
+**Properties:**
+- Mathematically rigorous: each topic has exactly equal expected probability of filling a slot
+- More complex to implement correctly (need reservoir sampling, not trivial in Dart)
+- Harder to unit-test the probabilistic behaviour
+- Subtle depletion handling: once a question is selected, weights renormalize
+
+**Verdict:** ⚠️ More principled mathematically, but overkill for this use case. Round-robin
+achieves the same player experience with far simpler code.
+
+---
+
+## Algorithm D — Equal Quota (Floor/Ceil Split)
+
+**Concept:** Divide `count` evenly across topics (`floor(count / numTopics)` per topic),
+distribute remainder randomly. Handle depletion by redistributing.
+
+```
+basePerTopic = count ÷ numTopics
+remainder    = count mod numTopics
+```
+
+**Properties:**
+- Strictly deterministic split before randomness — closest to enforced minimums
+- More complex depletion handling (need to redistribute)
+- Topic ordering during game would be predictable without a final shuffle
+- User explicitly said "don't enforce minimums" — this algorithm drifts that way
+
+**Verdict:** ❌ Drifts toward enforced minimums. Use round-robin instead.
+
+---
+
+## Comparison table
+
+| Algorithm | Fair? | Simple? | Handles depletion? | No hard minimums? |
+|-----------|-------|---------|-------------------|-------------------|
+| A — Flat pool (current) | ❌ | ✅ | ✅ | ✅ |
+| B — Round-robin | ✅ | ✅ | ✅ | ✅ |
+| C — Weighted sampling | ✅ | ❌ | ✅ | ✅ |
+| D — Equal quota | ✅ | ⚠️ | ⚠️ | ❌ |
+
+**Winner: Algorithm B — Round-Robin Interleaved.**

--- a/ai/tasks/fair-question-selection/proposal/02-variety-opportunities.md
+++ b/ai/tasks/fair-question-selection/proposal/02-variety-opportunities.md
@@ -1,0 +1,90 @@
+# Proposal 02: All Variety Opportunities in a Playthrough
+
+## Overview
+
+Five distinct layers where each playthrough can differ from the last.
+Layers 1–2 are the primary fix. Layers 3–5 are already working or future opportunities.
+
+---
+
+## Layer 1 — Topic Sampling (PRIMARY FIX, issue #44)
+
+**Current:** Flat pool → large topics dominate.
+**Fix:** Round-robin interleaved (see proposal 01).
+**Effect:** Every topic in the selected set has an equal expected contribution per game slot.
+Replaying the same topic selection produces different topic mixes each time.
+
+---
+
+## Layer 2 — Question Ordering Within the Game
+
+**Current:** After the flat-pool shuffle, there is no topic-interleaving guarantee.
+Questions from the same topic may cluster together.
+
+**With round-robin:** The pre-selection interleaving is broken by a final `shuffle()`,
+so the player sees no predictable topic pattern.
+
+**Alternative: Keep interleaved order (no final shuffle).**
+- Pros: topics alternate visibly → feels more varied mid-game
+- Cons: player could notice the pattern ("every other question is about crocheting")
+- Verdict: keep the final shuffle — variety feels natural, not mechanical
+
+**Opportunity (future):** Difficulty ramping — sort selected questions easy→medium→hard
+within the shuffled set. Not in scope for this fix but noted here.
+
+---
+
+## Layer 3 — Answer Option Randomization (ALREADY WORKING)
+
+Each call to `Question.toQuizQuestion()` independently:
+1. Picks 1 correct answer at random from `correctAnswers` (1–3 options)
+2. Picks 3 wrong answers at random from `wrongAnswers` (4–12 options)
+3. Shuffles all 4 into a random order
+
+**Effect:** The same question can appear with different wording for the correct answer,
+different distractors, and different button positions on every encounter.
+Questions with 3 correct answers and 12 wrong answers have enormous per-question variety.
+
+**No change needed.** This is already well-designed.
+
+---
+
+## Layer 4 — Topic Order Randomization (SMALL WIN, already in round-robin proposal)
+
+**Current:** Topics are merged in `topicIds.where(...)` order (Set iteration order, arbitrary).
+**With round-robin fix:** The topic list is shuffled before cycling, so the topic that
+"goes first" in round 1 changes each game.
+
+**Effect:** Even in a 2-topic game with equal representation (3 crocheting, 2 WAH),
+which topic fills slots 1/3/5 vs 2/4 is randomized.
+
+---
+
+## Layer 5 — Difficulty Sequence (FUTURE OPPORTUNITY)
+
+**Not implemented.** Questions have a `difficulty` field (`easy/medium/hard`).
+
+**Options:**
+- **Random** (current, implicit): No ordering by difficulty — already the default.
+- **Ramping:** Sort selected questions easy→medium→hard. Rewards progression.
+- **Oscillating:** easy, hard, medium, easy, hard, ... — keeps player on their toes.
+
+**Verdict:** Out of scope for this fix. Could be a separate feature (`quiz_config` field:
+`difficultyOrder: random | ramp | oscillate`).
+
+---
+
+## Summary: What Changes With the Fix
+
+| Playthrough 1 | Playthrough 2 | Reason |
+|---------------|---------------|--------|
+| 5 WAH questions | 3 WAH + 2 crocheting | Round-robin fair sampling |
+| Q order: WAH, WAH, WAH, WAH, WAH | Q order: WAH, crochet, WAH, crochet, WAH | Interleaved + shuffle |
+| Crocheting Q shows "yarn over" as correct | Same Q shows same correct answer | Only 1 correct answer exists |
+| Wrong answers: A, B, C | Wrong answers: A, D, C | Random wrong answer selection |
+| Option positions: correct=3rd | Option positions: correct=1st | Option shuffle |
+
+**Net effect:** Each playthrough with the same topic selection feels fresh because:
+1. Different questions are likely to appear from each topic
+2. Answer options are different for questions that support it
+3. Question order is different

--- a/ai/tasks/fair-question-selection/proposal/03-difficulty-bias-scale.md
+++ b/ai/tasks/fair-question-selection/proposal/03-difficulty-bias-scale.md
@@ -1,0 +1,135 @@
+# Proposal 03: Difficulty Bias Scale (1–5)
+
+## Goal
+Add a `difficultyBias` setting (1–5) to `QuizConfig` that controls how the question
+selection algorithm weights questions by difficulty. 1 = skewed toward easy,
+3 = balanced, 5 = skewed toward hard. No hard filter — all difficulties can appear,
+just with different probability.
+
+---
+
+## Current difficulty model
+
+`QuestionDifficulty` is an enum in `question.dart`: `easy | medium | hard`.
+Questions carry this field in their JSON. The selection layer ignores it entirely.
+
+---
+
+## Weight table
+
+| difficultyBias | easy | medium | hard | Feels like |
+|---------------|------|--------|------|-----------|
+| 1 | 5 | 2 | 0 | Almost all easy, rare medium, no hard |
+| 2 | 3 | 2 | 1 | Mostly easy, some medium, occasional hard |
+| 3 | 1 | 1 | 1 | Equal probability — current default behaviour |
+| 4 | 1 | 2 | 3 | Mostly hard, some medium, occasional easy |
+| 5 | 0 | 2 | 5 | Almost all hard, rare medium, no easy |
+
+Weight `0` means that difficulty is excluded from the pool, not just deprioritised.
+Topics with only easy questions still contribute questions at bias=5 (medium weight=2 is their fallback).
+
+---
+
+## Implementation: weighted shuffle within each topic bucket
+
+After each topic bucket is populated (before round-robin), apply a weighted in-place reorder:
+
+```dart
+/// Returns the selection weight for [q] given [bias] (1–5).
+int _difficultyWeight(Question q, int bias) {
+  final weights = switch (bias) {
+    1 => (easy: 5, medium: 2, hard: 0),
+    2 => (easy: 3, medium: 2, hard: 1),
+    4 => (easy: 1, medium: 2, hard: 3),
+    5 => (easy: 0, medium: 2, hard: 5),
+    _ => (easy: 1, medium: 1, hard: 1), // bias == 3 (default)
+  };
+  return switch (q.difficulty) {
+    QuestionDifficulty.easy   => weights.easy,
+    QuestionDifficulty.medium => weights.medium,
+    QuestionDifficulty.hard   => weights.hard,
+  };
+}
+
+/// Weighted shuffle: each question is repeated by its weight, the expanded
+/// list is shuffled, then deduplicated. The result is a bucket where
+/// high-weight questions are more likely to appear in early positions.
+List<Question> _weightedShuffle(List<Question> bucket, int bias, Random rng) {
+  if (bias == 3) {
+    // Uniform weights — plain shuffle is equivalent and cheaper.
+    return bucket..shuffle(rng);
+  }
+  final expanded = bucket
+      .expand((q) => List.filled(_difficultyWeight(q, bias), q))
+      .toList()
+    ..shuffle(rng);
+  final seen = <String>{};
+  return [for (final q in expanded) if (seen.add(q.id)) q];
+}
+```
+
+This approach:
+- Requires no change to `Question` or `QuizQuestion` models
+- Works cleanly with the round-robin loop — the bucket is just reordered
+- Gracefully handles topics with only one or two difficulty levels
+- Is O(n × maxWeight) space — worst case O(5n) which is fine for small topic sizes
+
+---
+
+## QuizConfig changes
+
+```dart
+class QuizConfig {
+  final Set<String> selectedTopicIds;
+  final int questionCount;
+  final GameMode gameMode;
+  final int difficultyBias; // 1–5, default 3
+
+  const QuizConfig({
+    required this.selectedTopicIds,
+    required this.questionCount,
+    this.gameMode = GameMode.standard,
+    this.difficultyBias = 3,
+  });
+
+  QuizConfig copyWith({
+    Set<String>? selectedTopicIds,
+    int? questionCount,
+    GameMode? gameMode,
+    int? difficultyBias,
+  }) => QuizConfig(
+    selectedTopicIds: selectedTopicIds ?? this.selectedTopicIds,
+    questionCount: questionCount ?? this.questionCount,
+    gameMode: gameMode ?? this.gameMode,
+    difficultyBias: difficultyBias ?? this.difficultyBias,
+  );
+}
+```
+
+---
+
+## Updated `selectQuestionsFrom` signature
+
+```dart
+List<QuizQuestion> selectQuestionsFrom(
+  List<Question> allQuestions, {
+  required Set<String> topicIds,
+  required int count,
+  int difficultyBias = 3,   // ← new parameter
+  Random? rng,
+})
+```
+
+The `GameStateNotifier.startGame` call passes `config.difficultyBias`.
+
+---
+
+## Edge cases
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Topic has only easy questions, bias=5 | easy weight=0, medium weight=2 but none exist → no questions from this topic in that round |
+| Topic has only easy questions, bias=4 | easy weight=1, contributes normally just less likely |
+| bias=3 | No weighted expansion — plain shuffle, same as before fix |
+| All topics have no hard questions, bias=5 | medium fallback (weight=2) provides all questions |
+| Endless mode, bias=1 | All questions selected; weighted shuffle still reorders for gameplay variety |

--- a/ai/tasks/fair-question-selection/proposal/04-difficulty-visual-cue.md
+++ b/ai/tasks/fair-question-selection/proposal/04-difficulty-visual-cue.md
@@ -1,0 +1,222 @@
+# Proposal 04: Difficulty Visual Cue on Question Card
+
+## Goal
+Show the current question's difficulty as a small badge on the `QuestionCard` widget,
+using an emoji + colour that fits the existing castle/medieval palette.
+
+---
+
+## Difficulty → visual mapping
+
+| Difficulty | Emoji | Colour | Rationale |
+|------------|-------|--------|-----------|
+| easy | 🕯️ | `torchGold` `#FFD700` | A candle — gentle, accessible light |
+| medium | 🔥 | `torchAmber` `#FF8C00` | A torch — the game's primary accent; familiar challenge |
+| hard | ⚔️ | `dangerRed` `#C0392B` | A sword — danger, difficulty, the existing error/lives colour |
+
+All three colours are already in `AppColors`. No new colours needed.
+
+---
+
+## Badge design
+
+A small pill/chip in the **bottom-left corner** of the `QuestionCard` (inside the card padding,
+below the question text). Sits alongside the existing book icon (top-right).
+
+```
+┌─────────────────────────────────────────┐
+│  Question text goes here, possibly      │ [📖]
+│  spanning two or three lines.           │
+│                                         │
+│  🕯️ Easy                                │
+└─────────────────────────────────────────┘
+```
+
+**Spec:**
+- Horizontal pill: emoji + label text
+- Background: difficulty colour at 15% opacity (matches the book icon style)
+- Border: difficulty colour at 45% opacity (matches the book icon style)
+- Text: difficulty colour at full opacity, `bodySmall` (12px Lora)
+- Padding: 4px vertical, 8px horizontal
+- Border radius: 12px (pill shape)
+
+---
+
+## Widget implementation
+
+Add a static helper method on `QuizQuestion` (or a standalone function in `app_theme.dart`):
+
+```dart
+// In question.dart — no new dependency
+({String emoji, Color color, String label}) get difficultyDisplay {
+  return switch (difficulty) {
+    QuestionDifficulty.easy   => (emoji: '🕯️', color: AppColors.torchGold,  label: 'Easy'),
+    QuestionDifficulty.medium => (emoji: '🔥', color: AppColors.torchAmber, label: 'Medium'),
+    QuestionDifficulty.hard   => (emoji: '⚔️', color: AppColors.dangerRed,  label: 'Hard'),
+  };
+}
+```
+
+**`QuestionCard` update** — add a `Column` wrapper and the badge below the question row:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final textTheme = Theme.of(context).textTheme;
+  final diff = question.difficultyDisplay;
+
+  return Card(
+    child: Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Existing: question text + book icon
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(question.question, style: ...),
+              ),
+              if (onArticleTap != null) ...[
+                const SizedBox(width: 10),
+                // existing book icon widget
+              ],
+            ],
+          ),
+
+          // New: difficulty badge
+          const SizedBox(height: 10),
+          _DifficultyBadge(emoji: diff.emoji, label: diff.label, color: diff.color),
+        ],
+      ),
+    ),
+  ).animate()...;
+}
+```
+
+**`_DifficultyBadge` widget** (private, file-local):
+
+```dart
+class _DifficultyBadge extends StatelessWidget {
+  final String emoji;
+  final String label;
+  final Color color;
+
+  const _DifficultyBadge({
+    required this.emoji,
+    required this.label,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.45)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 12)),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: color),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+---
+
+## Difficulty selector UI in `_BottomBar` (topic picker)
+
+Add a row of 5 tappable chips between the question-count row and the Start button.
+Use the castle theme: skulls or swords — but keep it readable.
+
+**Label row:** `🕯️ Easier ——————— ⚔️ Harder` with 5 numbered chips (1–5).
+
+```dart
+Row(
+  mainAxisAlignment: MainAxisAlignment.center,
+  children: [
+    Text('🕯️', style: TextStyle(fontSize: 14)),
+    const SizedBox(width: 6),
+    ...List.generate(5, (i) {
+      final value = i + 1;
+      final active = value == difficultyBias;
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 3),
+        child: GestureDetector(
+          onTap: () => onDifficultyChanged(value),
+          child: Container(
+            width: 36,
+            height: 36,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: active ? _biasColor(value) : AppColors.stone,
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(
+                color: active ? _biasColor(value) : AppColors.stoneMid,
+              ),
+            ),
+            child: Text(
+              '$value',
+              style: TextStyle(
+                color: active ? Colors.white : AppColors.textLight,
+                fontWeight: active ? FontWeight.bold : FontWeight.normal,
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ),
+      );
+    }),
+    const SizedBox(width: 6),
+    Text('⚔️', style: TextStyle(fontSize: 14)),
+  ],
+),
+```
+
+Where `_biasColor` interpolates between the three difficulty colours:
+```dart
+Color _biasColor(int bias) => switch (bias) {
+  1 => AppColors.torchGold,
+  2 => AppColors.torchGold,
+  3 => AppColors.torchAmber,
+  4 => AppColors.dangerRed,
+  5 => AppColors.dangerRed,
+  _ => AppColors.torchAmber,
+};
+```
+
+The `_BottomBar` receives two new parameters:
+```dart
+final int difficultyBias;
+final void Function(int) onDifficultyChanged;
+```
+
+And `_TopicPickerScreenState` adds:
+```dart
+int _difficultyBias = 3;
+```
+
+The `QuizConfig` is constructed with the value at game start.
+
+---
+
+## Files affected
+
+| File | Change |
+|------|--------|
+| `lib/features/gameplay/domain/models/question.dart` | Add `difficultyDisplay` getter to `QuizQuestion` |
+| `lib/features/gameplay/presentation/widgets/question_card.dart` | Add `_DifficultyBadge`, update `QuestionCard.build` |
+| `lib/features/start/presentation/screens/topic_picker_screen.dart` | Add difficulty chips row to `_BottomBar`; pass state through |

--- a/ai/tasks/fair-question-selection/research/current-state.md
+++ b/ai/tasks/fair-question-selection/research/current-state.md
@@ -1,0 +1,102 @@
+# Research: Current State of Question Selection & Variety
+
+## Current algorithm (`question_bank.dart:selectQuestionsFrom`)
+
+```dart
+final pool = allQuestions
+    .where((q) => topicIds.contains(q.topicId))
+    .toList()
+  ..shuffle();
+final selected = pool.take(count).toList();
+return selected.map((q) => q.toQuizQuestion()).toList();
+```
+
+**The bug:** Questions from all topics are merged into one flat pool and shuffled together.
+Probability of any question being selected = 1/totalQuestions.
+A topic with 25 questions is ~8× more likely to fill a slot than a topic with 3 questions.
+
+**Concrete example from the report:**
+- crocheting: 3 questions → 3/28 = 10.7% chance per slot
+- west_african_history: 25 questions → 25/28 = 89.3% chance per slot
+- With 5 slots, expected WAH questions: 4.46 — so all-WAH result is highly probable
+
+---
+
+## Topic question counts (as of 2026-04-14)
+
+| Count | Topics |
+|-------|--------|
+| 2 | physical_geography |
+| 3 | bridges, candy, chemical_engineering, crocheting, deep_sea, footwear, handheld_devices, mechanical_engineering, perfumes, plastics, water_bodies |
+| 4 | adhd, coffee_brewing, countries, pharmaceutical_drugs, recreational_drugs, therapy |
+| 5 | coffee, medieval_history, puzzles, theology |
+| 10 | socks |
+| 11 | anatomy, lily_mayne, medicine |
+| 12 | french_literature |
+| 13 | agatha_christie, autism, human_geography |
+| 14 | dictionaries |
+| 15 | linguistics |
+| 25 | west_african_history |
+| 33 | rocks |
+| 36 | tennis |
+| 40 | software_architecture |
+
+**Range:** 2–40 questions. 20× spread between smallest and largest.
+
+---
+
+## Existing randomization points (already working well)
+
+### 1. `question_bank.dart` — pool shuffle
+Pool is shuffled before `take(count)`. This handles question order randomness but is topic-unfair.
+
+### 2. `question.dart:toQuizQuestion()` — answer option randomization
+Each play through a question:
+- Randomly picks 1 from 1–3 correct answers
+- Randomly picks 3 from 4–12 wrong answers
+- Shuffles all 4 options
+
+**Result:** The same question can present differently on each encounter — different correct answer wording, different wrong answers, different option positions.
+
+### 3. `question_bank.dart` — full pool shuffle for question ordering
+After selection, question order is already random.
+
+---
+
+## All places variety can be introduced
+
+| Layer | What varies | Current state | Opportunity |
+|-------|-------------|---------------|-------------|
+| **Topic sampling** | Which topics contribute questions | Flat pool (unfair) | Fair per-topic sampling |
+| **Question ordering** | Sequence questions appear in-game | Random (but topic-clustered possible) | Interleaved topic ordering |
+| **Answer options** | Which correct answer shown, which 3 wrongs, option positions | ✅ Already random per play | No change needed |
+| **Difficulty sequence** | easy→hard or random ordering | Not implemented | Could ramp or randomize |
+| **Topic interleaving** | Whether questions alternate topics | Not guaranteed | Round-robin interleaving |
+
+---
+
+## Data flow for a game session
+
+```
+QuizConfig (selectedTopicIds, questionCount, gameMode)
+    ↓
+loadQuestionsForTopics()        ← loads raw Question objects from JSON assets
+    ↓
+selectQuestionsFrom()           ← THE BROKEN STEP
+    ↓
+Question.toQuizQuestion()       ← already randomizes answer options
+    ↓
+GameState.initial()
+    ↓
+GameState.currentQuestion       ← drives gameplay screen
+```
+
+---
+
+## Key constraints
+
+- No runtime network calls — all questions are bundled JSON assets
+- `loadQuestionsForTopics` returns a `List<Question>` (not a stream)
+- `selectQuestionsFrom` is a pure function — easy to test
+- Endless mode uses `pool.length` as count — the fix must still work for this
+- `toQuizQuestion` is called once per question, at selection time (not re-rolled at display time)

--- a/lib/features/gameplay/data/question_bank.dart
+++ b/lib/features/gameplay/data/question_bank.dart
@@ -1,17 +1,89 @@
+import 'dart:math';
+
 import '../domain/models/question.dart';
 
-/// Select [count] random [QuizQuestion]s from topics in [topicIds].
-/// Returns the shuffled list ready for a game session.
+/// Returns the selection weight for [q] given [bias] (1–5).
+/// Weight 0 means excluded from the weighted bucket.
+int _difficultyWeight(Question q, int bias) {
+  final (easy, medium, hard) = switch (bias) {
+    1 => (5, 2, 0),
+    2 => (3, 2, 1),
+    4 => (1, 2, 3),
+    5 => (0, 2, 5),
+    _ => (1, 1, 1), // bias == 3: uniform
+  };
+  return switch (q.difficulty) {
+    QuestionDifficulty.easy   => easy,
+    QuestionDifficulty.medium => medium,
+    QuestionDifficulty.hard   => hard,
+  };
+}
+
+/// Reorders [bucket] so higher-weight questions appear earlier on average.
+/// At bias=3 all weights are equal, so a plain shuffle is used instead.
+List<Question> _weightedShuffle(List<Question> bucket, int bias, Random rng) {
+  if (bias == 3) return bucket..shuffle(rng);
+
+  // Expand each question by its weight, shuffle, then deduplicate.
+  final expanded = bucket
+      .expand((q) {
+        final w = _difficultyWeight(q, bias);
+        return w > 0 ? List.filled(w, q) : const <Question>[];
+      })
+      .toList()
+    ..shuffle(rng);
+
+  final seen = <String>{};
+  return [for (final q in expanded) if (seen.add(q.id)) q];
+}
+
+/// Selects [count] questions from [allQuestions] filtered to [topicIds].
+///
+/// Uses round-robin interleaving so each topic has equal expected representation
+/// regardless of pool size. Within each topic bucket, questions are reordered
+/// by [difficultyBias] (1 = easy-skewed, 3 = balanced, 5 = hard-skewed).
+/// The final list is shuffled so no topic pattern is visible to the player.
 List<QuizQuestion> selectQuestionsFrom(
   List<Question> allQuestions, {
   required Set<String> topicIds,
   required int count,
+  int difficultyBias = 3,
+  Random? rng,
 }) {
-  final pool = allQuestions
-      .where((q) => topicIds.contains(q.topicId))
-      .toList()
-    ..shuffle();
+  final random = rng ?? Random();
 
-  final selected = pool.take(count).toList();
-  return selected.map((q) => q.toQuizQuestion()).toList();
+  // Group by topic and apply difficulty weighting within each bucket.
+  final buckets = <String, List<Question>>{};
+  for (final q in allQuestions) {
+    if (topicIds.contains(q.topicId)) {
+      (buckets[q.topicId] ??= []).add(q);
+    }
+  }
+  for (final key in buckets.keys) {
+    buckets[key] = _weightedShuffle(buckets[key]!, difficultyBias, random);
+  }
+
+  // Shuffle topic order so the first-mover advantage is randomised.
+  final topicList = buckets.keys.toList()..shuffle(random);
+
+  // Round-robin: one question per topic per round.
+  final selected = <Question>[];
+  var round = 0;
+  while (selected.length < count) {
+    var anyAdded = false;
+    for (final topicId in topicList) {
+      if (selected.length >= count) break;
+      final bucket = buckets[topicId]!;
+      if (round < bucket.length) {
+        selected.add(bucket[round]);
+        anyAdded = true;
+      }
+    }
+    if (!anyAdded) break; // all buckets exhausted
+    round++;
+  }
+
+  // Final shuffle so no interleaving pattern is visible.
+  selected.shuffle(random);
+  return selected.map((q) => q.toQuizQuestion(random)).toList();
 }

--- a/lib/features/gameplay/domain/models/question.dart
+++ b/lib/features/gameplay/domain/models/question.dart
@@ -1,5 +1,9 @@
 import 'dart:math';
 
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_theme.dart';
+
 enum QuestionDifficulty {
   easy,
   medium,
@@ -113,4 +117,12 @@ class QuizQuestion {
   String get articleUrl => source.articleUrl;
   String get topicId => source.topicId;
   QuestionDifficulty get difficulty => source.difficulty;
+
+  /// Visual representation of this question's difficulty.
+  ({String emoji, Color color, String label}) get difficultyDisplay =>
+      switch (difficulty) {
+        QuestionDifficulty.easy   => (emoji: '🕯️', color: AppColors.torchGold,  label: 'Easy'),
+        QuestionDifficulty.medium => (emoji: '🔥', color: AppColors.torchAmber, label: 'Medium'),
+        QuestionDifficulty.hard   => (emoji: '⚔️', color: AppColors.dangerRed,  label: 'Hard'),
+      };
 }

--- a/lib/features/gameplay/domain/models/quiz_config.dart
+++ b/lib/features/gameplay/domain/models/quiz_config.dart
@@ -5,11 +5,14 @@ class QuizConfig {
   final Set<String> selectedTopicIds;
   final int questionCount; // 5, 10, or 20 — ignored in endless mode
   final GameMode gameMode;
+  /// 1 = skewed easy, 3 = balanced (default), 5 = skewed hard.
+  final int difficultyBias;
 
   const QuizConfig({
     required this.selectedTopicIds,
     required this.questionCount,
     this.gameMode = GameMode.standard,
+    this.difficultyBias = 3,
   });
 
   static const List<int> validCounts = [5, 10, 20];
@@ -18,11 +21,13 @@ class QuizConfig {
     Set<String>? selectedTopicIds,
     int? questionCount,
     GameMode? gameMode,
+    int? difficultyBias,
   }) {
     return QuizConfig(
       selectedTopicIds: selectedTopicIds ?? this.selectedTopicIds,
       questionCount: questionCount ?? this.questionCount,
       gameMode: gameMode ?? this.gameMode,
+      difficultyBias: difficultyBias ?? this.difficultyBias,
     );
   }
 }

--- a/lib/features/gameplay/presentation/providers/game_state_provider.dart
+++ b/lib/features/gameplay/presentation/providers/game_state_provider.dart
@@ -19,6 +19,7 @@ class GameStateNotifier extends Notifier<GameState?> {
       pool,
       topicIds: config.selectedTopicIds,
       count: count,
+      difficultyBias: config.difficultyBias,
     );
     state = GameState.initial(questions: questions, config: config);
   }

--- a/lib/features/gameplay/presentation/widgets/question_card.dart
+++ b/lib/features/gameplay/presentation/widgets/question_card.dart
@@ -16,43 +16,56 @@ class QuestionCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final diff = question.difficultyDisplay;
 
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
-        child: Row(
+        child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Expanded(
-              child: Text(
-                question.question,
-                style: textTheme.bodyLarge?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  fontSize: 16,
-                  color: AppColors.textDark,
-                ),
-              ),
-            ),
-            if (onArticleTap != null) ...[
-              const SizedBox(width: 10),
-              Tooltip(
-                message: question.articleTitle,
-                child: GestureDetector(
-                  onTap: onArticleTap,
-                  child: Container(
-                    padding: const EdgeInsets.all(7),
-                    decoration: BoxDecoration(
-                      color: AppColors.torchAmber.withValues(alpha: 0.15),
-                      borderRadius: BorderRadius.circular(8),
-                      border: Border.all(
-                          color: AppColors.torchAmber.withValues(alpha: 0.45)),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Text(
+                    question.question,
+                    style: textTheme.bodyLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 16,
+                      color: AppColors.textDark,
                     ),
-                    child: const Icon(Icons.menu_book,
-                        size: 18, color: AppColors.torchAmber),
                   ),
                 ),
-              ),
-            ],
+                if (onArticleTap != null) ...[
+                  const SizedBox(width: 10),
+                  Tooltip(
+                    message: question.articleTitle,
+                    child: GestureDetector(
+                      onTap: onArticleTap,
+                      child: Container(
+                        padding: const EdgeInsets.all(7),
+                        decoration: BoxDecoration(
+                          color: AppColors.torchAmber.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(
+                              color: AppColors.torchAmber.withValues(alpha: 0.45)),
+                        ),
+                        child: const Icon(Icons.menu_book,
+                            size: 18, color: AppColors.torchAmber),
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+            const SizedBox(height: 10),
+            _DifficultyBadge(
+              emoji: diff.emoji,
+              label: diff.label,
+              color: diff.color,
+            ),
           ],
         ),
       ),
@@ -60,6 +73,41 @@ class QuestionCard extends StatelessWidget {
         .animate()
         .fadeIn(duration: 350.ms)
         .slideY(begin: 0.08, end: 0, duration: 350.ms, curve: Curves.easeOut);
+  }
+}
+
+class _DifficultyBadge extends StatelessWidget {
+  final String emoji;
+  final String label;
+  final Color color;
+
+  const _DifficultyBadge({
+    required this.emoji,
+    required this.label,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.45)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 12)),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: color),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/features/start/presentation/screens/topic_picker_screen.dart
+++ b/lib/features/start/presentation/screens/topic_picker_screen.dart
@@ -22,6 +22,7 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
   late Set<String> _selected;
   int _questionCount = 10;
   GameMode _gameMode = GameMode.standard;
+  int _difficultyBias = 3;
 
   @override
   void initState() {
@@ -30,6 +31,7 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
     _selected = Set.from(config.selectedTopicIds);
     _questionCount = config.questionCount;
     _gameMode = config.gameMode;
+    _difficultyBias = config.difficultyBias;
   }
 
   bool get _canStart =>
@@ -85,6 +87,7 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
       selectedTopicIds: Set.from(_selected),
       questionCount: _questionCount,
       gameMode: _gameMode,
+      difficultyBias: _difficultyBias,
     );
     ref.read(quizConfigProvider.notifier).setConfig(config);
     await ref.read(gameStateProvider.notifier).startGame(config);
@@ -160,9 +163,11 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
             questionCount: _questionCount,
             availableQuestions: _availableQuestions,
             gameMode: _gameMode,
+            difficultyBias: _difficultyBias,
             canStart: _canStart,
             onCountChanged: (c) => setState(() => _questionCount = c),
             onModeChanged: (m) => setState(() => _gameMode = m),
+            onDifficultyChanged: (b) => setState(() => _difficultyBias = b),
             onStart: _startGame,
           ),
         ],
@@ -378,18 +383,22 @@ class _BottomBar extends StatelessWidget {
   final int questionCount;
   final int availableQuestions;
   final GameMode gameMode;
+  final int difficultyBias;
   final bool canStart;
   final void Function(int) onCountChanged;
   final void Function(GameMode) onModeChanged;
+  final void Function(int) onDifficultyChanged;
   final VoidCallback onStart;
 
   const _BottomBar({
     required this.questionCount,
     required this.availableQuestions,
     required this.gameMode,
+    required this.difficultyBias,
     required this.canStart,
     required this.onCountChanged,
     required this.onModeChanged,
+    required this.onDifficultyChanged,
     required this.onStart,
   });
 
@@ -487,6 +496,49 @@ class _BottomBar extends StatelessWidget {
                     textTheme.bodySmall?.copyWith(color: AppColors.dangerRed),
               ),
             ),
+          const SizedBox(height: 10),
+
+          // Difficulty bias selector
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('🕯️', style: TextStyle(fontSize: 14)),
+              const SizedBox(width: 6),
+              ...List.generate(5, (i) {
+                final value = i + 1;
+                final active = value == difficultyBias;
+                final chipColor = _biasColor(value);
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 3),
+                  child: GestureDetector(
+                    onTap: () => onDifficultyChanged(value),
+                    child: Container(
+                      width: 36,
+                      height: 36,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: active ? chipColor : AppColors.stone,
+                        borderRadius: BorderRadius.circular(6),
+                        border: Border.all(
+                          color: active ? chipColor : AppColors.stoneMid,
+                        ),
+                      ),
+                      child: Text(
+                        '$value',
+                        style: TextStyle(
+                          color: active ? Colors.white : AppColors.textLight,
+                          fontWeight: active ? FontWeight.bold : FontWeight.normal,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              }),
+              const SizedBox(width: 6),
+              const Text('⚔️', style: TextStyle(fontSize: 14)),
+            ],
+          ),
           const SizedBox(height: 12),
           SizedBox(
             width: double.infinity,
@@ -511,6 +563,12 @@ class _BottomBar extends StatelessWidget {
     );
   }
 }
+
+Color _biasColor(int bias) => switch (bias) {
+  1 || 2 => AppColors.torchGold,
+  4 || 5 => AppColors.dangerRed,
+  _       => AppColors.torchAmber,
+};
 
 class _ModeChip extends StatelessWidget {
   final String label;

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,9 @@
 - Auto-check for app updates on launch — update dialog appears automatically when a new version is available
 - In-app update dialog now renders release notes as formatted markdown with full scrollable content
 - Download button now triggers a direct APK download instead of opening the browser release page
+- Fair multi-topic question selection — round-robin interleaving ensures every selected topic has equal representation regardless of pool size (#44)
+- Difficulty bias selector (1–5) on the topic picker — tune your game from easy-skewed to hard-skewed before starting (#44)
+- Visual difficulty badge on each question card: 🕯️ Easy · 🔥 Medium · ⚔️ Hard (#44)
 
 ### Fixes
 - (none)

--- a/test/question_bank_test.dart
+++ b/test/question_bank_test.dart
@@ -1,0 +1,147 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mind_maze/features/gameplay/data/question_bank.dart';
+import 'package:mind_maze/features/gameplay/domain/models/question.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Question _makeQuestion(String id, String topicId, QuestionDifficulty difficulty) {
+  return Question(
+    id: id,
+    question: 'Q $id',
+    correctAnswers: ['correct'],
+    wrongAnswers: ['w1', 'w2', 'w3', 'w4'],
+    funFact: 'fact',
+    articleTitle: '',
+    articleUrl: '',
+    topicId: topicId,
+    difficulty: difficulty,
+  );
+}
+
+List<Question> _topic(String id, int count, [QuestionDifficulty diff = QuestionDifficulty.medium]) =>
+    List.generate(count, (i) => _makeQuestion('$id-$i', id, diff));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('selectQuestionsFrom — topic fairness', () {
+    test('single topic: returns count questions from that topic', () {
+      final questions = _topic('A', 10);
+      final result = selectQuestionsFrom(questions, topicIds: {'A'}, count: 5);
+      expect(result.length, 5);
+      expect(result.every((q) => q.topicId == 'A'), isTrue);
+    });
+
+    test('two equal-size topics: both appear in output', () {
+      final questions = [..._topic('A', 10), ..._topic('B', 10)];
+      final result = selectQuestionsFrom(questions, topicIds: {'A', 'B'}, count: 6);
+      expect(result.length, 6);
+      expect(result.any((q) => q.topicId == 'A'), isTrue);
+      expect(result.any((q) => q.topicId == 'B'), isTrue);
+    });
+
+    test('two unequal topics (3 vs 25): small topic always appears', () {
+      final questions = [..._topic('small', 3), ..._topic('big', 25)];
+      // Run 20 times — small topic should always appear because round-robin
+      // guarantees it gets a slot in round 1.
+      for (var i = 0; i < 20; i++) {
+        final result = selectQuestionsFrom(
+          questions,
+          topicIds: {'small', 'big'},
+          count: 5,
+          rng: Random(i),
+        );
+        expect(result.any((q) => q.topicId == 'small'), isTrue,
+            reason: 'small topic missing on seed $i');
+      }
+    });
+
+    test('count > total questions returns all available questions', () {
+      final questions = [..._topic('A', 3), ..._topic('B', 4)];
+      final result = selectQuestionsFrom(questions, topicIds: {'A', 'B'}, count: 100);
+      expect(result.length, 7);
+    });
+
+    test('missing topic id is silently ignored', () {
+      final questions = _topic('A', 5);
+      final result = selectQuestionsFrom(questions, topicIds: {'A', 'missing'}, count: 3);
+      expect(result.length, 3);
+      expect(result.every((q) => q.topicId == 'A'), isTrue);
+    });
+
+    test('no duplicate questions in output', () {
+      final questions = [..._topic('A', 10), ..._topic('B', 10)];
+      final result = selectQuestionsFrom(questions, topicIds: {'A', 'B'}, count: 10);
+      final ids = result.map((q) => q.source.id).toSet();
+      expect(ids.length, result.length);
+    });
+  });
+
+  group('selectQuestionsFrom — difficulty bias', () {
+    List<Question> mixedTopic(String topicId) => [
+          ...List.generate(5, (i) => _makeQuestion('$topicId-e$i', topicId, QuestionDifficulty.easy)),
+          ...List.generate(5, (i) => _makeQuestion('$topicId-m$i', topicId, QuestionDifficulty.medium)),
+          ...List.generate(5, (i) => _makeQuestion('$topicId-h$i', topicId, QuestionDifficulty.hard)),
+        ];
+
+    test('bias=1 excludes hard questions when easy/medium available', () {
+      final questions = mixedTopic('A');
+      final result = selectQuestionsFrom(questions,
+          topicIds: {'A'}, count: 5, difficultyBias: 1, rng: Random(42));
+      expect(result.every((q) => q.difficulty != QuestionDifficulty.hard), isTrue);
+    });
+
+    test('bias=5 excludes easy questions when medium/hard available', () {
+      final questions = mixedTopic('A');
+      final result = selectQuestionsFrom(questions,
+          topicIds: {'A'}, count: 5, difficultyBias: 5, rng: Random(42));
+      expect(result.every((q) => q.difficulty != QuestionDifficulty.easy), isTrue);
+    });
+
+    test('bias=3 returns questions of any difficulty', () {
+      final questions = mixedTopic('A');
+      final difficulties = <QuestionDifficulty>{};
+      for (var i = 0; i < 30; i++) {
+        final result = selectQuestionsFrom(questions,
+            topicIds: {'A'}, count: 5, difficultyBias: 3, rng: Random(i));
+        for (final q in result) {
+          difficulties.add(q.difficulty);
+        }
+      }
+      expect(difficulties, containsAll(QuestionDifficulty.values));
+    });
+
+    test('bias=5 with only easy questions returns 0 (no medium/hard fallback exists)', () {
+      final questions = _topic('A', 5, QuestionDifficulty.easy);
+      // easy weight=0, medium/hard absent — weighted bucket is empty
+      final result = selectQuestionsFrom(questions,
+          topicIds: {'A'}, count: 3, difficultyBias: 5, rng: Random(0));
+      expect(result.length, 0);
+    });
+  });
+
+  group('selectQuestionsFrom — round-robin fairness across many runs', () {
+    test('small topic (3) vs large topic (25): small averages ≥ 1 question over 100 runs', () {
+      final questions = [..._topic('small', 3), ..._topic('big', 25)];
+      var smallCount = 0;
+      for (var i = 0; i < 100; i++) {
+        final result = selectQuestionsFrom(
+          questions,
+          topicIds: {'small', 'big'},
+          count: 5,
+          rng: Random(i),
+        );
+        smallCount += result.where((q) => q.topicId == 'small').length;
+      }
+      // On average, small topic should contribute at least 2 questions per run
+      // (round-robin gives it ~50% of slots in a 2-topic game).
+      expect(smallCount / 100.0, greaterThanOrEqualTo(2.0));
+    });
+  });
+}


### PR DESCRIPTION
Closes #44

Fixes uneven topic representation when selecting topics with different question counts, and adds a difficulty bias control + visual difficulty badge.

## What changed

### Fair topic selection
Replaced the flat-pool shuffle in `question_bank.dart` with a round-robin interleaved algorithm. Questions are grouped by topic into independent buckets; the algorithm cycles through topics one question at a time. Result: each selected topic has equal expected representation regardless of pool size. Crocheting (3 questions) and West African History (25 questions) now each contribute roughly 50% of slots in a 2-topic game.

### Difficulty bias (1–5)
Added `difficultyBias` field to `QuizConfig`. A new chip row in the topic picker's bottom bar lets players tune difficulty before starting:
- `🕯️ 1` — skewed toward easy (hard excluded)
- `3` — balanced (default, unchanged behaviour)
- `⚔️ 5` — skewed toward hard (easy excluded)

Implemented via weighted shuffle within each topic bucket — higher-weight questions appear earlier and are more likely to be drawn in early rounds.

### Visual difficulty badge
Each question card now shows a small pill badge in the bottom-left:
- 🕯️ Easy — `torchGold`
- 🔥 Medium — `torchAmber`
- ⚔️ Hard — `dangerRed`

All colours use existing `AppColors` constants. No new packages added.

## Files changed
- `question_bank.dart` — round-robin + weighted shuffle algorithm
- `quiz_config.dart` — `difficultyBias` field
- `game_state_provider.dart` — pass bias to selection
- `question.dart` — `difficultyDisplay` getter on `QuizQuestion`
- `question_card.dart` — `_DifficultyBadge` widget
- `topic_picker_screen.dart` — difficulty chip row in `_BottomBar`
- `test/question_bank_test.dart` — 11 new unit tests (fairness, weighting, edge cases)

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes (49 tests)
- [ ] Select Crocheting + West African History, 5 questions — both topics appear across multiple playthroughs
- [ ] Set difficulty to 1 — questions feel noticeably easier
- [ ] Set difficulty to 5 — questions feel noticeably harder
- [ ] Each question card shows the correct emoji/colour badge
- [ ] Difficulty chips in topic picker highlight with the matching colour