### PR TITLE
fix: update download no longer hangs (#60)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <application
         android:label="Mind Mazeish"
         android:name="${applicationName}"
@@ -26,6 +27,16 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- FileProvider required by open_filex to serve APK URIs to the package installer -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.open_filex.file_provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/open_filex_file_paths" />
+        </provider>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/lib/features/start/presentation/screens/start_screen.dart
+++ b/lib/features/start/presentation/screens/start_screen.dart
@@ -1,9 +1,14 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:open_filex/open_filex.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../core/theme/app_theme.dart';
@@ -253,10 +258,12 @@ class _VersionBadgeState extends ConsumerState<_VersionBadge> {
           ElevatedButton(
             onPressed: () {
               Navigator.of(context).pop();
-              launchUrl(
-                Uri.parse(info.downloadUrl),
-                mode: LaunchMode.externalApplication,
-              );
+              if (UpdateService.isDirectApkUrl(info.downloadUrl)) {
+                _downloadAndInstall(info);
+              } else {
+                launchUrl(Uri.parse(info.downloadUrl),
+                    mode: LaunchMode.externalApplication);
+              }
             },
             style: ElevatedButton.styleFrom(
               backgroundColor: AppColors.torchGold,
@@ -267,6 +274,100 @@ class _VersionBadgeState extends ConsumerState<_VersionBadge> {
         ],
       ),
     );
+  }
+
+  Future<void> _downloadAndInstall(UpdateInfo info) async {
+    if (!mounted) return;
+
+    final progressNotifier = ValueNotifier<double?>(null);
+    var cancelled = false;
+
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => PopScope(
+        canPop: false,
+        child: AlertDialog(
+          backgroundColor: AppColors.stoneDark,
+          title: const Text('Downloading update…',
+              style: TextStyle(color: AppColors.textLight)),
+          content: ValueListenableBuilder<double?>(
+            valueListenable: progressNotifier,
+            builder: (_, v, __) => Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                LinearProgressIndicator(
+                  value: v,
+                  backgroundColor: AppColors.stone,
+                  valueColor:
+                      const AlwaysStoppedAnimation(AppColors.torchGold),
+                ),
+                if (v != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      '${(v * 100).round()}%',
+                      style: const TextStyle(
+                          color: AppColors.textLight, fontSize: 12),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                cancelled = true;
+                Navigator.of(ctx).pop();
+              },
+              child: const Text('Cancel',
+                  style: TextStyle(color: AppColors.torchAmber)),
+            ),
+          ],
+        ),
+      ),
+    ).whenComplete(progressNotifier.dispose);
+
+    try {
+      final tempDir = await getTemporaryDirectory();
+      final savePath = '${tempDir.path}/mind_mazeish_update.apk';
+
+      final client = http.Client();
+      try {
+        final request = http.Request('GET', Uri.parse(info.downloadUrl));
+        final response = await client.send(request);
+        final total = response.contentLength ?? 0;
+        var received = 0;
+
+        final file = File(savePath);
+        final sink = file.openWrite();
+        await for (final chunk in response.stream) {
+          if (cancelled) {
+            await sink.close();
+            return;
+          }
+          sink.add(chunk);
+          received += chunk.length;
+          if (total > 0) progressNotifier.value = received / total;
+        }
+        await sink.flush();
+        await sink.close();
+      } finally {
+        client.close();
+      }
+
+      if (cancelled || !mounted) return;
+      final nav = Navigator.of(context);
+      if (nav.canPop()) nav.pop();
+
+      await OpenFilex.open(savePath);
+    } catch (_) {
+      if (mounted) {
+        final nav = Navigator.of(context);
+        if (nav.canPop()) nav.pop();
+        _showSnack('Download failed. Please try again.');
+      }
+    }
   }
 
   void _showSnack(String msg) {

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -61,4 +61,9 @@ class UpdateService {
       return null;
     }
   }
+
+  /// Returns true when [url] points directly to an APK file.
+  /// Returns false when it is the GitHub release HTML page (the fallback
+  /// used when no APK asset is attached to the release).
+  static bool isDirectApkUrl(String url) => url.endsWith('.apk');
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -496,6 +496,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  open_filex:
+    dependency: "direct main"
+    description:
+      name: open_filex
+      sha256: "9976da61b6a72302cf3b1efbce259200cd40232643a467aac7370addf94d6900"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.0"
   package_config:
     dependency: transitive
     description:
@@ -529,7 +537,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   shared_preferences: ^2.5.5
   http: ^1.2.1
   url_launcher: ^6.3.0
+  path_provider: ^2.1.4
+  open_filex: ^4.7.0
   package_info_plus: ^10.0.0
   flutter_markdown: ^0.7.6
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -11,7 +11,7 @@
 - Visual difficulty badge on each question card: 🕯️ Easy · 🔥 Medium · ⚔️ Hard (#44)
 
 ### Fixes
-- (none)
+- Update download no longer hangs — replaced browser-delegated download with an in-app HTTP download that shows a progress indicator, then opens the package installer directly (#60)
 
 ### Content
 - Added 86 questions for Deep Sea (Physical World) with 10 new Wikipedia sources

--- a/test/services/update_service_test.dart
+++ b/test/services/update_service_test.dart
@@ -38,6 +38,18 @@ void main() {
       expect(info.downloadUrl, equals(info.releaseUrl));
     });
 
+    test('isDirectApkUrl returns true for browser_download_url APK assets', () {
+      const apkUrl =
+          'https://github.com/sai-pher/mind-mazeish/releases/download/v1.0.42/app-release.apk';
+      expect(UpdateService.isDirectApkUrl(apkUrl), isTrue);
+    });
+
+    test('isDirectApkUrl returns false for HTML release page fallback', () {
+      const releasePageUrl =
+          'https://github.com/sai-pher/mind-mazeish/releases/tag/v1.0.42';
+      expect(UpdateService.isDirectApkUrl(releasePageUrl), isFalse);
+    });
+
     test('releaseNotes carries full markdown without truncation', () {
       final longNotes = '### Features\n${'- Item\n' * 50}';
       final info = UpdateInfo(


### PR DESCRIPTION
Closes #60

**Root cause:** The download button called `launchUrl(..., mode: LaunchMode.externalApplication)`, handing the GitHub `browser_download_url` to Chrome. Chrome's download manager stalls on GitHub's CDN redirect chain on Android 16, leaving the progress dialog stuck and producing an unopenable file. Additionally, when no `.apk` asset is attached to the release, the URL silently falls back to the HTML release page — triggering no download at all.

**Fix:** Replace the browser-delegated download with a fully in-app flow:
1. `http.Client` streams the APK bytes with live progress tracking
2. A `ValueNotifier`-backed dialog shows an indeterminate spinner until the first byte arrives, then a percentage indicator
3. On completion, `OpenFilex.open()` invokes the Android package installer directly via a FileProvider URI
4. `UpdateService.isDirectApkUrl()` distinguishes APK URLs from HTML fallback URLs — APK URLs go through the in-app downloader; HTML URLs fall back to `launchUrl` to open the release page

**New dependencies:** `path_provider ^2.1.4`, `open_filex ^4.7.0`

**Android manifest:** Added `REQUEST_INSTALL_PACKAGES` permission and the `FileProvider` entry required by `open_filex`.

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes — 2 new regression tests for `UpdateService.isDirectApkUrl`
- [ ] Manual: tap Download in the update dialog → progress bar fills → package installer opens
- [ ] Manual: verify cancel button dismisses the dialog and stops the download