### PR TITLE
fix: archive and reset release notes after each release (#61)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -143,3 +143,14 @@ jobs:
           prerelease: true
           make_latest: false
           files: ${{ steps.apk.outputs.path }}
+
+      - name: Archive release notes and reset Unreleased
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/archive_release_notes.py "1.0.${BUILD_NUMBER}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add release_notes.md
+          git commit -m "chore: archive release notes for v1.0.${BUILD_NUMBER} [skip ci]"
+          git push origin main

--- a/release_notes.md
+++ b/release_notes.md
@@ -21,6 +21,7 @@
 - Added 100 questions for Lily Mayne (literature & arts)
 
 ### Other
+- CD pipeline now archives `## Unreleased` as a versioned section and resets it to empty stubs after each release (#61)
 - Added `flutter_markdown` package for in-app markdown rendering
 - `release_notes.md` introduced as single source of truth for release notes (replaces ad hoc git log in CD workflow)
 - CI action `check-release-notes` added — PRs to `main` must update this file

--- a/scripts/archive_release_notes.py
+++ b/scripts/archive_release_notes.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Archive the ## Unreleased section of release_notes.md after a release.
+
+Usage:
+    python3 scripts/archive_release_notes.py <version>   e.g. 1.0.36
+
+What it does:
+  1. Extracts the current ## Unreleased content.
+  2. Inserts it as ## v<version> immediately after the --- separator.
+  3. Resets ## Unreleased to empty section stubs.
+
+The file is rewritten in-place.
+"""
+
+import re
+import sys
+
+
+FRESH_UNRELEASED = (
+    "## Unreleased\n\n"
+    "### Features\n- (none)\n\n"
+    "### Fixes\n- (none)\n\n"
+    "### Content\n- (none)\n\n"
+    "### Other\n- (none)\n"
+)
+
+
+def archive(content: str, version: str) -> str:
+    """Return rewritten release_notes.md content with Unreleased archived."""
+    # Match the Unreleased block up to (but not including) the --- separator.
+    m = re.search(r"## Unreleased\n(.*?)(?=\n---)", content, re.DOTALL)
+    if not m:
+        raise ValueError("No '## Unreleased' section followed by '---' found")
+
+    unreleased_body = m.group(1).strip()
+    archived_block = f"## v{version}\n{unreleased_body}\n"
+
+    # Replace the Unreleased block with fresh stubs.
+    new_content = re.sub(
+        r"## Unreleased\n.*?(?=\n---)",
+        FRESH_UNRELEASED.rstrip(),
+        content,
+        flags=re.DOTALL,
+    )
+
+    # Insert the archived block immediately after the first --- separator.
+    new_content = new_content.replace("\n---\n", f"\n---\n\n{archived_block}", 1)
+
+    return new_content
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <version>", file=sys.stderr)
+        sys.exit(1)
+
+    version = sys.argv[1]
+    path = "release_notes.md"
+
+    with open(path) as f:
+        content = f.read()
+
+    new_content = archive(content, version)
+
+    with open(path, "w") as f:
+        f.write(new_content)
+
+    print(f"Archived ## Unreleased as ## v{version} and reset to empty stubs")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_archive_release_notes.py
+++ b/scripts/test_archive_release_notes.py
@@ -1,0 +1,107 @@
+"""
+Regression tests for scripts/archive_release_notes.py
+
+Run with:  python3 scripts/test_archive_release_notes.py
+"""
+
+import sys
+import textwrap
+import unittest
+
+sys.path.insert(0, "scripts")
+from archive_release_notes import archive, FRESH_UNRELEASED  # noqa: E402
+
+
+SAMPLE = textwrap.dedent("""\
+    # Release Notes
+
+    ## Unreleased
+
+    ### Features
+    - Some cool feature (#10)
+
+    ### Fixes
+    - A bug fix (#11)
+
+    ### Content
+    - (none)
+
+    ### Other
+    - (none)
+
+    ---
+
+    ## v1.0.25 — 2026-02-01
+    ### Other
+    - Dependency bumps
+""")
+
+
+class TestArchive(unittest.TestCase):
+    def _run(self, version="1.0.36"):
+        return archive(SAMPLE, version)
+
+    # --- reset behaviour ---
+
+    def test_unreleased_resets_to_empty_stubs(self):
+        result = self._run()
+        # The fresh block must appear before the --- separator
+        unreleased_idx = result.index("## Unreleased")
+        sep_idx = result.index("\n---\n")
+        self.assertLess(unreleased_idx, sep_idx)
+        # Each section stub must be present
+        for stub in ("### Features\n- (none)", "### Fixes\n- (none)",
+                     "### Content\n- (none)", "### Other\n- (none)"):
+            self.assertIn(stub, result[:sep_idx])
+
+    def test_shipped_bullets_absent_from_new_unreleased_block(self):
+        result = self._run()
+        sep_idx = result.index("\n---\n")
+        unreleased_section = result[:sep_idx]
+        self.assertNotIn("Some cool feature", unreleased_section)
+        self.assertNotIn("A bug fix", unreleased_section)
+
+    # --- archive behaviour ---
+
+    def test_archived_block_present_after_separator(self):
+        result = self._run("1.0.36")
+        sep_idx = result.index("\n---\n")
+        after_sep = result[sep_idx:]
+        self.assertIn("## v1.0.36", after_sep)
+
+    def test_archived_block_contains_shipped_bullets(self):
+        result = self._run("1.0.36")
+        sep_idx = result.index("\n---\n")
+        after_sep = result[sep_idx:]
+        self.assertIn("Some cool feature (#10)", after_sep)
+        self.assertIn("A bug fix (#11)", after_sep)
+
+    def test_archived_block_appears_before_older_versions(self):
+        result = self._run("1.0.36")
+        new_idx = result.index("## v1.0.36")
+        old_idx = result.index("## v1.0.25")
+        self.assertLess(new_idx, old_idx)
+
+    def test_version_string_used_verbatim(self):
+        result = archive(SAMPLE, "2.0.0")
+        self.assertIn("## v2.0.0", result)
+
+    # --- idempotency / structure ---
+
+    def test_original_versioned_section_preserved(self):
+        result = self._run()
+        self.assertIn("## v1.0.25 — 2026-02-01", result)
+        self.assertIn("Dependency bumps", result)
+
+    def test_only_one_unreleased_heading_in_output(self):
+        result = self._run()
+        self.assertEqual(result.count("## Unreleased"), 1)
+
+    def test_raises_when_no_unreleased_section(self):
+        bad = "# Release Notes\n\n## v1.0.0\n- stuff\n"
+        with self.assertRaises(ValueError):
+            archive(bad, "1.0.36")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #61

**Root cause:** The CD workflow extracted `## Unreleased` to build the GitHub Release body but never modified `release_notes.md` afterwards. Every subsequent PR added to a growing list that had already been fully shipped — v1.0.34 re-shipped everything from v1.0.33, v1.0.35 re-shipped everything from v1.0.34, etc.

**Fix:** Added a final step to the CD workflow — `Archive release notes and reset Unreleased` — that runs after the GitHub Release is published:
1. Calls `scripts/archive_release_notes.py v{version}` to move the current `## Unreleased` content to a new `## v{version}` section immediately after the `---` separator
2. Resets `## Unreleased` to empty section stubs (`- (none)`)
3. Commits the modified file back to `main` with `[skip ci]` to avoid triggering another build

The Python logic is extracted to `scripts/archive_release_notes.py` with 9 unit tests in `scripts/test_archive_release_notes.py` covering reset behaviour, archive placement, version string, idempotency, and error handling.

## Test plan
- [ ] `python3 scripts/test_archive_release_notes.py` — 9 tests, 0 failures
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes (51 tests)
- [ ] Manual: merge a PR to `main`, confirm the next CD run creates a `## v{version}` section in `release_notes.md` and the `## Unreleased` block is reset to empty stubs