### PR TITLE
feat: settings page, local user ID, and open issues view (#45)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,7 @@ import 'features/results/presentation/screens/results_screen.dart';
 import 'features/notebook/presentation/screens/notebook_screen.dart';
 import 'features/feedback/presentation/screens/feedback_screen.dart';
 import 'features/start/presentation/screens/question_stats_screen.dart';
+import 'features/settings/presentation/screens/settings_screen.dart';
 
 final _router = GoRouter(
   initialLocation: '/',
@@ -33,6 +34,7 @@ final _router = GoRouter(
     GoRoute(path: '/notebook', builder: (_, __) => const NotebookScreen()),
     GoRoute(path: '/feedback', builder: (_, __) => const FeedbackScreen()),
     GoRoute(path: '/stats', builder: (_, __) => const QuestionStatsScreen()),
+    GoRoute(path: '/settings', builder: (_, __) => const SettingsScreen()),
   ],
 );
 

--- a/lib/features/feedback/data/github_issue_service.dart
+++ b/lib/features/feedback/data/github_issue_service.dart
@@ -28,6 +28,30 @@ enum ContentRequestType {
   final String label;
 }
 
+/// A minimal view of a GitHub issue returned by [GithubIssueService.fetchOpenIssues].
+class IssueItem {
+  final int number;
+  final String title;
+  final List<String> labelNames;
+  final DateTime createdAt;
+
+  const IssueItem({
+    required this.number,
+    required this.title,
+    required this.labelNames,
+    required this.createdAt,
+  });
+
+  factory IssueItem.fromJson(Map<String, dynamic> json) => IssueItem(
+        number: json['number'] as int,
+        title: json['title'] as String,
+        labelNames: (json['labels'] as List)
+            .map((l) => l['name'] as String)
+            .toList(),
+        createdAt: DateTime.parse(json['created_at'] as String),
+      );
+}
+
 class GithubIssueService {
   static final _client = http.Client();
 
@@ -36,6 +60,7 @@ class GithubIssueService {
     required String title,
     required String body,
     String? appVersion,
+    String? userId,
   }) async {
     final issueBody = '''
 ${body.trim()}
@@ -43,7 +68,7 @@ ${body.trim()}
 ---
 **Category:** ${category.emoji} ${category.label}
 **App version:** ${appVersion ?? 'unknown'}
-**Source:** In-app feedback
+${userId != null ? '**User ID:** `$userId`\n' : ''}**Source:** In-app feedback
 ''';
 
     return _createIssue(
@@ -59,6 +84,7 @@ ${body.trim()}
     required String body,
     String? topicId,
     String? appVersion,
+    String? userId,
   }) async {
     final issueBody = '''
 ${body.trim()}
@@ -66,7 +92,7 @@ ${body.trim()}
 ---
 **Request type:** ${type.label}
 ${topicId != null ? '**Topic ID:** `$topicId`\n' : ''}**App version:** ${appVersion ?? 'unknown'}
-**Source:** In-app content request
+${userId != null ? '**User ID:** `$userId`\n' : ''}**Source:** In-app content request
 ''';
 
     return _createIssue(
@@ -76,23 +102,64 @@ ${topicId != null ? '**Topic ID:** `$topicId`\n' : ''}**App version:** ${appVers
     );
   }
 
+  /// Fetches open issues tagged with [alpha-feedback] (most recent first).
+  static Future<List<IssueItem>> fetchOpenIssues({int perPage = 30}) async {
+    if (_kGithubToken.isEmpty) return [];
+    try {
+      final uri = Uri.parse(
+        'https://api.github.com/repos/$_kRepoOwner/$_kRepoName/issues'
+        '?state=open&labels=alpha-feedback&per_page=$perPage&sort=created&direction=desc',
+      );
+      final response = await _client
+          .get(uri, headers: _headers)
+          .timeout(const Duration(seconds: 15));
+      if (response.statusCode != 200) return [];
+      final list = jsonDecode(response.body) as List;
+      return list
+          .map((j) => IssueItem.fromJson(j as Map<String, dynamic>))
+          .toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// Adds a comment to an existing issue. Returns true on success.
+  static Future<bool> addComment({
+    required int issueNumber,
+    required String body,
+    String? userId,
+  }) async {
+    if (_kGithubToken.isEmpty) return false;
+    final commentBody = userId != null
+        ? '$body\n\n---\n**User ID:** `$userId`'
+        : body;
+    try {
+      final response = await _client
+          .post(
+            Uri.parse(
+                'https://api.github.com/repos/$_kRepoOwner/$_kRepoName/issues/$issueNumber/comments'),
+            headers: _headers,
+            body: jsonEncode({'body': commentBody}),
+          )
+          .timeout(const Duration(seconds: 15));
+      return response.statusCode == 201;
+    } catch (_) {
+      return false;
+    }
+  }
+
   static Future<bool> _createIssue({
     required String title,
     required String body,
     required List<String> labels,
   }) async {
-    if (_kGithubToken == 'REPLACE_WITH_WRITE_ONLY_PAT') return false;
+    if (_kGithubToken.isEmpty) return false;
     try {
       final response = await _client
           .post(
             Uri.parse(
                 'https://api.github.com/repos/$_kRepoOwner/$_kRepoName/issues'),
-            headers: {
-              'Authorization': 'Bearer $_kGithubToken',
-              'Accept': 'application/vnd.github+json',
-              'X-GitHub-Api-Version': '2022-11-28',
-              'Content-Type': 'application/json',
-            },
+            headers: _headers,
             body: jsonEncode({
               'title': title,
               'body': body,
@@ -105,4 +172,11 @@ ${topicId != null ? '**Topic ID:** `$topicId`\n' : ''}**App version:** ${appVers
       return false;
     }
   }
+
+  static Map<String, String> get _headers => {
+        'Authorization': 'Bearer $_kGithubToken',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      };
 }

--- a/lib/features/feedback/presentation/screens/feedback_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_screen.dart
@@ -4,6 +4,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import '../../../../core/theme/app_theme.dart';
 import '../../../gameplay/data/topic_registry.dart';
+import '../../../settings/data/user_profile_service.dart';
 import '../../data/github_issue_service.dart';
 
 class FeedbackScreen extends StatefulWidget {
@@ -17,6 +18,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _tabs;
   String? _appVersion;
+  String? _userId;
 
   @override
   void initState() {
@@ -24,6 +26,9 @@ class _FeedbackScreenState extends State<FeedbackScreen>
     _tabs = TabController(length: 2, vsync: this);
     PackageInfo.fromPlatform().then((i) {
       if (mounted) setState(() => _appVersion = '${i.version}+${i.buildNumber}');
+    });
+    UserProfileService.getUserId().then((id) {
+      if (mounted) setState(() => _userId = id);
     });
   }
 
@@ -54,8 +59,8 @@ class _FeedbackScreenState extends State<FeedbackScreen>
       body: TabBarView(
         controller: _tabs,
         children: [
-          _GeneralFeedbackTab(appVersion: _appVersion),
-          _ContentRequestTab(appVersion: _appVersion),
+          _GeneralFeedbackTab(appVersion: _appVersion, userId: _userId),
+          _ContentRequestTab(appVersion: _appVersion, userId: _userId),
         ],
       ),
     );
@@ -68,7 +73,8 @@ class _FeedbackScreenState extends State<FeedbackScreen>
 
 class _GeneralFeedbackTab extends StatefulWidget {
   final String? appVersion;
-  const _GeneralFeedbackTab({this.appVersion});
+  final String? userId;
+  const _GeneralFeedbackTab({this.appVersion, this.userId});
 
   @override
   State<_GeneralFeedbackTab> createState() => _GeneralFeedbackTabState();
@@ -98,6 +104,7 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
       title: _titleCtrl.text.trim(),
       body: _bodyCtrl.text.trim(),
       appVersion: widget.appVersion,
+      userId: widget.userId,
     );
     if (!mounted) return;
     setState(() => _submitting = false);
@@ -153,7 +160,8 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
             controller: _bodyCtrl,
             label: 'Details',
             hint: 'Describe the issue or idea in as much detail as you like…',
-            maxLines: 6,
+            minLines: 6,
+            maxLines: null,
           ),
           const SizedBox(height: 24),
           SizedBox(
@@ -191,7 +199,8 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
 
 class _ContentRequestTab extends StatefulWidget {
   final String? appVersion;
-  const _ContentRequestTab({this.appVersion});
+  final String? userId;
+  const _ContentRequestTab({this.appVersion, this.userId});
 
   @override
   State<_ContentRequestTab> createState() => _ContentRequestTabState();
@@ -229,6 +238,7 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
           : _bodyCtrl.text.trim(),
       topicId: _selectedTopicId,
       appVersion: widget.appVersion,
+      userId: widget.userId,
     );
     if (!mounted) return;
     setState(() => _submitting = false);
@@ -293,7 +303,8 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
               controller: _bodyCtrl,
               label: 'Why this topic? (optional)',
               hint: 'Tell us why you\'d love to see this topic in the game…',
-              maxLines: 4,
+              minLines: 4,
+              maxLines: null,
             ),
           ] else ...[
             Text('Which topic?', style: tt.labelLarge?.copyWith(color: AppColors.textLight)),
@@ -333,7 +344,8 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
               controller: _bodyCtrl,
               label: 'Additional notes (optional)',
               hint: 'Any specific questions or areas to cover?',
-              maxLines: 4,
+              minLines: 4,
+              maxLines: null,
             ),
           ],
 
@@ -369,13 +381,16 @@ class _Field extends StatelessWidget {
   final TextEditingController controller;
   final String label;
   final String hint;
-  final int maxLines;
+  final int minLines;
+  // null = unbounded (expands with content, avoids internal scroll conflicts)
+  final int? maxLines;
 
   const _Field({
     required this.controller,
     required this.label,
     required this.hint,
-    required this.maxLines,
+    this.minLines = 1,
+    this.maxLines = 1,
   });
 
   @override
@@ -391,6 +406,7 @@ class _Field extends StatelessWidget {
         const SizedBox(height: 6),
         TextField(
           controller: controller,
+          minLines: minLines,
           maxLines: maxLines,
           style: const TextStyle(color: AppColors.textLight),
           decoration: InputDecoration(

--- a/lib/features/settings/data/user_profile_service.dart
+++ b/lib/features/settings/data/user_profile_service.dart
@@ -1,0 +1,29 @@
+import 'dart:math';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Manages a stable, anonymous local user identifier.
+///
+/// The ID is generated once on first use (`usr_` + 12 random hex characters)
+/// and persisted in shared_preferences. It is attached to all feedback
+/// submissions so reports from the same tester can be grouped without
+/// requiring an account.
+class UserProfileService {
+  static const _key = 'user_profile_id';
+
+  /// Returns the stored user ID, generating one if none exists yet.
+  static Future<String> getUserId() async {
+    final prefs = await SharedPreferences.getInstance();
+    var id = prefs.getString(_key);
+    if (id == null || id.isEmpty) {
+      id = _generateId();
+      await prefs.setString(_key, id);
+    }
+    return id;
+  }
+
+  static String _generateId() {
+    final rand = Random.secure();
+    final hex = List.generate(12, (_) => rand.nextInt(16).toRadixString(16)).join();
+    return 'usr_$hex';
+  }
+}

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -1,0 +1,383 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../feedback/data/github_issue_service.dart';
+import '../../data/user_profile_service.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  String? _userId;
+  String? _appVersion;
+  late Future<List<IssueItem>> _issuesFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _issuesFuture = GithubIssueService.fetchOpenIssues();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final results = await Future.wait([
+      UserProfileService.getUserId(),
+      PackageInfo.fromPlatform().then((i) => '${i.version}+${i.buildNumber}'),
+    ]);
+    if (!mounted) return;
+    setState(() {
+      _userId     = results[0];
+      _appVersion = results[1];
+    });
+  }
+
+  void _copyUserId() {
+    if (_userId == null) return;
+    Clipboard.setData(ClipboardData(text: _userId!));
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('User ID copied to clipboard')),
+    );
+  }
+
+  void _showAddComment(IssueItem issue) {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: AppColors.stoneDark,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(16))),
+      builder: (ctx) => _AddCommentSheet(
+        issue: issue,
+        userId: _userId,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.stoneDark,
+        title: const Text('Settings'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        children: [
+          // ── Profile ──────────────────────────────────────────────────────
+          const _SectionHeader('Profile'),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Card(
+              color: AppColors.stone,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8)),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Anonymous tester ID',
+                      style: tt.labelMedium?.copyWith(color: AppColors.parchment),
+                    ),
+                    const SizedBox(height: 6),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            _userId ?? '…',
+                            style: tt.bodyMedium?.copyWith(
+                              color: AppColors.torchAmber,
+                              fontFamily: 'monospace',
+                              letterSpacing: 1,
+                            ),
+                          ),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.copy_outlined,
+                              size: 18, color: AppColors.torchAmber),
+                          tooltip: 'Copy ID',
+                          onPressed: _copyUserId,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'This ID is stored only on your device and is attached '
+                      'to all feedback you submit.',
+                      style: tt.bodySmall?.copyWith(
+                          color: AppColors.textLight.withValues(alpha: 0.5)),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+          // ── Feedback ─────────────────────────────────────────────────────
+          const _SectionHeader('Feedback'),
+          ListTile(
+            leading: const Icon(Icons.feedback_outlined,
+                color: AppColors.torchAmber),
+            title: const Text('Give Feedback',
+                style: TextStyle(color: AppColors.textLight)),
+            subtitle: Text(
+              'Report a bug, request a feature, or suggest content',
+              style: tt.bodySmall?.copyWith(
+                  color: AppColors.textLight.withValues(alpha: 0.5)),
+            ),
+            trailing: const Icon(Icons.chevron_right,
+                color: AppColors.stoneMid),
+            onTap: () => context.push('/feedback'),
+          ),
+
+          // ── Open Issues ──────────────────────────────────────────────────
+          const _SectionHeader('Open Issues'),
+          FutureBuilder<List<IssueItem>>(
+            future: _issuesFuture,
+            builder: (context, snap) {
+              if (snap.connectionState != ConnectionState.done) {
+                return const Padding(
+                  padding: EdgeInsets.all(24),
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              }
+              final issues = snap.data ?? [];
+              if (issues.isEmpty) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16, vertical: 12),
+                  child: Text(
+                    'No open issues — or unable to reach GitHub.',
+                    style: tt.bodySmall?.copyWith(
+                        color: AppColors.textLight.withValues(alpha: 0.4)),
+                  ),
+                );
+              }
+              return Column(
+                children: issues.map((issue) {
+                  return ListTile(
+                    leading: CircleAvatar(
+                      backgroundColor: AppColors.stone,
+                      radius: 16,
+                      child: Text(
+                        '#${issue.number}',
+                        style: const TextStyle(
+                            color: AppColors.torchAmber,
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    title: Text(
+                      issue.title,
+                      style: const TextStyle(
+                          color: AppColors.textLight, fontSize: 13),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    subtitle: issue.labelNames.isNotEmpty
+                        ? Text(
+                            issue.labelNames.join(' · '),
+                            style: TextStyle(
+                                color: AppColors.textLight.withValues(alpha: 0.45),
+                                fontSize: 11),
+                          )
+                        : null,
+                    trailing: TextButton(
+                      onPressed: () => _showAddComment(issue),
+                      style: TextButton.styleFrom(
+                          foregroundColor: AppColors.torchAmber),
+                      child: const Text('Comment',
+                          style: TextStyle(fontSize: 12)),
+                    ),
+                    contentPadding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+                  );
+                }).toList(),
+              );
+            },
+          ),
+
+          // ── App ──────────────────────────────────────────────────────────
+          const _SectionHeader('App'),
+          ListTile(
+            leading: const Icon(Icons.info_outline, color: AppColors.stoneMid),
+            title: const Text('Version',
+                style: TextStyle(color: AppColors.textLight)),
+            trailing: Text(
+              _appVersion ?? '…',
+              style: tt.bodySmall?.copyWith(
+                  color: AppColors.textLight.withValues(alpha: 0.5)),
+            ),
+          ),
+
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section header
+// ---------------------------------------------------------------------------
+
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  const _SectionHeader(this.title);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 4),
+      child: Text(
+        title.toUpperCase(),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: AppColors.torchAmber.withValues(alpha: 0.7),
+              letterSpacing: 1.2,
+            ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Add comment bottom sheet
+// ---------------------------------------------------------------------------
+
+class _AddCommentSheet extends StatefulWidget {
+  final IssueItem issue;
+  final String? userId;
+
+  const _AddCommentSheet({required this.issue, this.userId});
+
+  @override
+  State<_AddCommentSheet> createState() => _AddCommentSheetState();
+}
+
+class _AddCommentSheetState extends State<_AddCommentSheet> {
+  final _ctrl = TextEditingController();
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_ctrl.text.trim().isEmpty) return;
+    setState(() => _submitting = true);
+    final ok = await GithubIssueService.addComment(
+      issueNumber: widget.issue.number,
+      body: _ctrl.text.trim(),
+      userId: widget.userId,
+    );
+    if (!mounted) return;
+    setState(() => _submitting = false);
+    if (ok) {
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Comment added — thank you!')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content:
+                Text('Could not submit — check your connection and try again.')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+        left: 20,
+        right: 20,
+        top: 20,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Add comment to #${widget.issue.number}',
+            style: tt.titleSmall?.copyWith(color: AppColors.parchment),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            widget.issue.title,
+            style: tt.bodySmall?.copyWith(
+                color: AppColors.textLight.withValues(alpha: 0.55)),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _ctrl,
+            minLines: 3,
+            maxLines: null,
+            autofocus: true,
+            style: const TextStyle(color: AppColors.textLight),
+            decoration: InputDecoration(
+              hintText: 'Add any additional context, updates, or follow-up…',
+              hintStyle: TextStyle(
+                  color: AppColors.textLight.withValues(alpha: 0.4),
+                  fontSize: 13),
+              filled: true,
+              fillColor: AppColors.stone,
+              border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: const BorderSide(color: AppColors.stoneMid)),
+              enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: BorderSide(
+                      color: AppColors.stoneMid.withValues(alpha: 0.6))),
+              focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: const BorderSide(
+                      color: AppColors.torchAmber, width: 1.5)),
+              contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 12, vertical: 10),
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: _submitting ? null : _submit,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.torchAmber,
+                foregroundColor: AppColors.textDark,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              icon: _submitting
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(
+                          strokeWidth: 2, color: AppColors.textDark))
+                  : const Icon(Icons.comment_outlined),
+              label: Text(_submitting ? 'Submitting…' : 'Submit Comment',
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
+            ),
+          ),
+          const SizedBox(height: 20),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/start/presentation/screens/start_screen.dart
+++ b/lib/features/start/presentation/screens/start_screen.dart
@@ -125,13 +125,13 @@ class StartScreen extends ConsumerWidget {
 
                     const SizedBox(height: 4),
 
-                    // Feedback button
+                    // Settings button (feedback + issues accessible from there)
                     TextButton.icon(
-                      onPressed: () => context.push('/feedback'),
-                      icon: Icon(Icons.feedback_outlined,
+                      onPressed: () => context.push('/settings'),
+                      icon: Icon(Icons.settings_outlined,
                           size: 18,
                           color: AppColors.textLight.withValues(alpha: 0.55)),
-                      label: Text('Feedback',
+                      label: Text('Settings',
                           style: textTheme.labelMedium?.copyWith(
                               color: AppColors.textLight
                                   .withValues(alpha: 0.55))),

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Features
+- Settings page — new screen accessible from the start screen with user profile, feedback, open issues, and app info (#45)
+- Anonymous tester ID — generated locally on first launch and attached to all feedback submissions for grouping without accounts (#45)
+- Comment on open issues — view active alpha-feedback issues in Settings and add follow-up comments directly from the app (#45)
 - Auto-check for app updates on launch — update dialog appears automatically when a new version is available
 - In-app update dialog now renders release notes as formatted markdown with full scrollable content
 - Download button now triggers a direct APK download instead of opening the browser release page


### PR DESCRIPTION
Closes #45

## What changed

### New: Settings screen (`/settings`)
A new screen replaces the Feedback text button on the start screen. It has three sections:

| Section | Content |
|---------|---------|
| **Profile** | Anonymous tester ID (copy to clipboard) |
| **Feedback & Issues** | Give Feedback → `/feedback`; scrollable list of open `alpha-feedback` issues with "Comment" action |
| **App** | Current version display |

### New: `UserProfileService`
- Generates a stable `usr_<12 hex>` ID on first launch using `dart:math` `Random.secure()`
- Persists in `shared_preferences`
- All `submitFeedback()` and `submitContentRequest()` calls now include `User ID` in the issue body

### New: `GithubIssueService` additions
- `fetchOpenIssues()` — `GET /issues?state=open&labels=alpha-feedback` (uses existing PAT); returns `List<IssueItem>`
- `addComment()` — `POST /issues/{n}/comments` with user ID attached

### Out of scope
- Screenshot capture/upload — requires `image_picker`/gallery package not in pubspec
- Closing open issues from within the app — tracked in this issue for follow-up alongside user identity improvements

Changed files:
- `lib/features/settings/data/user_profile_service.dart` — new
- `lib/features/settings/presentation/screens/settings_screen.dart` — new
- `lib/features/feedback/data/github_issue_service.dart` — `IssueItem` model, `fetchOpenIssues`, `addComment`, `userId` param on submit methods
- `lib/features/feedback/presentation/screens/feedback_screen.dart` — loads + passes `userId`; `_Field` updated to `minLines`/`maxLines: null`
- `lib/features/start/presentation/screens/start_screen.dart` — Feedback button → Settings button
- `lib/app.dart` — `/settings` route added

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes
- [ ] Manual: start screen shows "Settings" instead of "Feedback"
- [ ] Manual: tap Settings → screen opens with Profile, Feedback & Issues, App sections
- [ ] Manual: user ID shown in Profile; tap copy icon → ID on clipboard
- [ ] Manual: re-launch app → same user ID (persisted)
- [ ] Manual: submit feedback → GitHub issue body includes `User ID: usr_...` line
- [ ] Manual: Open Issues section lists current open alpha-feedback issues
- [ ] Manual: tap "Comment" on an issue → bottom sheet opens; submit comment → posted on GitHub issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)