### PR TITLE
feat: feedback improvements — bug report form, draft saving, settings page (#45, #48, #49)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,7 @@ import 'features/results/presentation/screens/results_screen.dart';
 import 'features/notebook/presentation/screens/notebook_screen.dart';
 import 'features/feedback/presentation/screens/feedback_screen.dart';
 import 'features/start/presentation/screens/question_stats_screen.dart';
+import 'features/settings/presentation/screens/settings_screen.dart';
 
 final _router = GoRouter(
   initialLocation: '/',
@@ -33,6 +34,7 @@ final _router = GoRouter(
     GoRoute(path: '/notebook', builder: (_, __) => const NotebookScreen()),
     GoRoute(path: '/feedback', builder: (_, __) => const FeedbackScreen()),
     GoRoute(path: '/stats', builder: (_, __) => const QuestionStatsScreen()),
+    GoRoute(path: '/settings', builder: (_, __) => const SettingsScreen()),
   ],
 );
 

--- a/lib/features/feedback/data/feedback_draft_repository.dart
+++ b/lib/features/feedback/data/feedback_draft_repository.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// A draft feedback session that has been saved locally but not yet submitted.
+class FeedbackDraft {
+  final String id;
+
+  /// 'general' or 'content'
+  final String type;
+
+  /// Flat map of field name → value (varies by type; see field name constants).
+  final Map<String, String> fields;
+
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  // Field name constants for each type.
+  static const fieldTitle       = 'title';
+  static const fieldBody        = 'body';
+  static const fieldCategory    = 'category';   // general
+  static const fieldRequestType = 'requestType'; // content
+  static const fieldTopicId     = 'topicId';     // content
+
+  const FeedbackDraft({
+    required this.id,
+    required this.type,
+    required this.fields,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory FeedbackDraft.fromJson(Map<String, dynamic> json) => FeedbackDraft(
+        id: json['id'] as String,
+        type: json['type'] as String,
+        fields: Map<String, String>.from(json['fields'] as Map),
+        createdAt: DateTime.parse(json['createdAt'] as String),
+        updatedAt: DateTime.parse(json['updatedAt'] as String),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'type': type,
+        'fields': fields,
+        'createdAt': createdAt.toIso8601String(),
+        'updatedAt': updatedAt.toIso8601String(),
+      };
+
+  FeedbackDraft copyWithUpdated(Map<String, String> newFields) => FeedbackDraft(
+        id: id,
+        type: type,
+        fields: newFields,
+        createdAt: createdAt,
+        updatedAt: DateTime.now(),
+      );
+
+  String get displayTitle => fields[fieldTitle]?.isNotEmpty == true
+      ? fields[fieldTitle]!
+      : '(no title)';
+}
+
+class FeedbackDraftRepository {
+  static const _key = 'feedback_drafts_v1';
+
+  Future<List<FeedbackDraft>> loadAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_key) ?? [];
+    return raw
+        .map((s) {
+          try {
+            return FeedbackDraft.fromJson(jsonDecode(s) as Map<String, dynamic>);
+          } catch (_) {
+            return null;
+          }
+        })
+        .whereType<FeedbackDraft>()
+        .toList();
+  }
+
+  Future<void> save(FeedbackDraft draft) async {
+    final prefs = await SharedPreferences.getInstance();
+    final existing = await loadAll();
+    final updated = [
+      draft,
+      ...existing.where((d) => d.id != draft.id),
+    ];
+    await prefs.setStringList(
+      _key,
+      updated.map((d) => jsonEncode(d.toJson())).toList(),
+    );
+  }
+
+  Future<void> delete(String id) async {
+    final prefs = await SharedPreferences.getInstance();
+    final existing = await loadAll();
+    await prefs.setStringList(
+      _key,
+      existing
+          .where((d) => d.id != id)
+          .map((d) => jsonEncode(d.toJson()))
+          .toList(),
+    );
+  }
+}

--- a/lib/features/feedback/data/github_issue_service.dart
+++ b/lib/features/feedback/data/github_issue_service.dart
@@ -53,6 +53,41 @@ ${body.trim()}
     );
   }
 
+  static Future<bool> submitBugReport({
+    required String title,
+    required String given,
+    required String when,
+    required String thenExpected,
+    required String butActually,
+    String? supportingDetails,
+    String? appVersion,
+  }) async {
+    final issueBody = '''
+**Given**
+${given.trim()}
+
+**When**
+${when.trim()}
+
+**Then Expected**
+${thenExpected.trim()}
+
+**But Actually**
+${butActually.trim()}
+
+${supportingDetails != null && supportingDetails.trim().isNotEmpty ? '**Supporting details**\n${supportingDetails.trim()}\n\n' : ''}---
+**Category:** 🐛 Bug Report
+**App version:** ${appVersion ?? 'unknown'}
+**Source:** In-app feedback
+''';
+
+    return _createIssue(
+      title: '[Bug Report] $title',
+      body: issueBody,
+      labels: ['bug', 'alpha-feedback'],
+    );
+  }
+
   static Future<bool> submitContentRequest({
     required ContentRequestType type,
     required String title,

--- a/lib/features/feedback/data/github_issue_service.dart
+++ b/lib/features/feedback/data/github_issue_service.dart
@@ -28,6 +28,30 @@ enum ContentRequestType {
   final String label;
 }
 
+/// A minimal view of a GitHub issue returned by [GithubIssueService.fetchOpenIssues].
+class IssueItem {
+  final int number;
+  final String title;
+  final List<String> labelNames;
+  final DateTime createdAt;
+
+  const IssueItem({
+    required this.number,
+    required this.title,
+    required this.labelNames,
+    required this.createdAt,
+  });
+
+  factory IssueItem.fromJson(Map<String, dynamic> json) => IssueItem(
+        number: json['number'] as int,
+        title: json['title'] as String,
+        labelNames: (json['labels'] as List)
+            .map((l) => l['name'] as String)
+            .toList(),
+        createdAt: DateTime.parse(json['created_at'] as String),
+      );
+}
+
 class GithubIssueService {
   static final _client = http.Client();
 
@@ -36,6 +60,7 @@ class GithubIssueService {
     required String title,
     required String body,
     String? appVersion,
+    String? userId,
   }) async {
     final issueBody = '''
 ${body.trim()}
@@ -43,7 +68,7 @@ ${body.trim()}
 ---
 **Category:** ${category.emoji} ${category.label}
 **App version:** ${appVersion ?? 'unknown'}
-**Source:** In-app feedback
+${userId != null ? '**User ID:** `$userId`\n' : ''}**Source:** In-app feedback
 ''';
 
     return _createIssue(
@@ -59,6 +84,7 @@ ${body.trim()}
     required String body,
     String? topicId,
     String? appVersion,
+    String? userId,
   }) async {
     final issueBody = '''
 ${body.trim()}
@@ -66,7 +92,7 @@ ${body.trim()}
 ---
 **Request type:** ${type.label}
 ${topicId != null ? '**Topic ID:** `$topicId`\n' : ''}**App version:** ${appVersion ?? 'unknown'}
-**Source:** In-app content request
+${userId != null ? '**User ID:** `$userId`\n' : ''}**Source:** In-app content request
 ''';
 
     return _createIssue(
@@ -76,23 +102,64 @@ ${topicId != null ? '**Topic ID:** `$topicId`\n' : ''}**App version:** ${appVers
     );
   }
 
+  /// Fetches open issues tagged with [alpha-feedback] (most recent first).
+  static Future<List<IssueItem>> fetchOpenIssues({int perPage = 30}) async {
+    if (_kGithubToken.isEmpty) return [];
+    try {
+      final uri = Uri.parse(
+        'https://api.github.com/repos/$_kRepoOwner/$_kRepoName/issues'
+        '?state=open&labels=alpha-feedback&per_page=$perPage&sort=created&direction=desc',
+      );
+      final response = await _client
+          .get(uri, headers: _headers)
+          .timeout(const Duration(seconds: 15));
+      if (response.statusCode != 200) return [];
+      final list = jsonDecode(response.body) as List;
+      return list
+          .map((j) => IssueItem.fromJson(j as Map<String, dynamic>))
+          .toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// Adds a comment to an existing issue. Returns true on success.
+  static Future<bool> addComment({
+    required int issueNumber,
+    required String body,
+    String? userId,
+  }) async {
+    if (_kGithubToken.isEmpty) return false;
+    final commentBody = userId != null
+        ? '$body\n\n---\n**User ID:** `$userId`'
+        : body;
+    try {
+      final response = await _client
+          .post(
+            Uri.parse(
+                'https://api.github.com/repos/$_kRepoOwner/$_kRepoName/issues/$issueNumber/comments'),
+            headers: _headers,
+            body: jsonEncode({'body': commentBody}),
+          )
+          .timeout(const Duration(seconds: 15));
+      return response.statusCode == 201;
+    } catch (_) {
+      return false;
+    }
+  }
+
   static Future<bool> _createIssue({
     required String title,
     required String body,
     required List<String> labels,
   }) async {
-    if (_kGithubToken == 'REPLACE_WITH_WRITE_ONLY_PAT') return false;
+    if (_kGithubToken.isEmpty) return false;
     try {
       final response = await _client
           .post(
             Uri.parse(
                 'https://api.github.com/repos/$_kRepoOwner/$_kRepoName/issues'),
-            headers: {
-              'Authorization': 'Bearer $_kGithubToken',
-              'Accept': 'application/vnd.github+json',
-              'X-GitHub-Api-Version': '2022-11-28',
-              'Content-Type': 'application/json',
-            },
+            headers: _headers,
             body: jsonEncode({
               'title': title,
               'body': body,
@@ -105,4 +172,11 @@ ${topicId != null ? '**Topic ID:** `$topicId`\n' : ''}**App version:** ${appVers
       return false;
     }
   }
+
+  static Map<String, String> get _headers => {
+        'Authorization': 'Bearer $_kGithubToken',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      };
 }

--- a/lib/features/feedback/presentation/screens/feedback_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_screen.dart
@@ -21,7 +21,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
   @override
   void initState() {
     super.initState();
-    _tabs = TabController(length: 2, vsync: this);
+    _tabs = TabController(length: 3, vsync: this);
     PackageInfo.fromPlatform().then((i) {
       if (mounted) setState(() => _appVersion = '${i.version}+${i.buildNumber}');
     });
@@ -47,7 +47,8 @@ class _FeedbackScreenState extends State<FeedbackScreen>
           unselectedLabelColor: AppColors.textLight,
           tabs: const [
             Tab(icon: Icon(Icons.chat_bubble_outline), text: 'General'),
-            Tab(icon: Icon(Icons.library_add_outlined), text: 'Content Request'),
+            Tab(icon: Icon(Icons.bug_report_outlined), text: 'Bug Report'),
+            Tab(icon: Icon(Icons.library_add_outlined), text: 'Content'),
           ],
         ),
       ),
@@ -55,6 +56,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
         controller: _tabs,
         children: [
           _GeneralFeedbackTab(appVersion: _appVersion),
+          _BugReportTab(appVersion: _appVersion),
           _ContentRequestTab(appVersion: _appVersion),
         ],
       ),
@@ -170,6 +172,166 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
                       child: CircularProgressIndicator(strokeWidth: 2, color: AppColors.textDark))
                   : const Icon(Icons.send),
               label: Text(_submitting ? 'Submitting…' : 'Submit Feedback',
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
+            ),
+          ),
+          if (widget.appVersion != null) ...[
+            const SizedBox(height: 12),
+            Text('v${widget.appVersion}',
+                style: tt.labelSmall?.copyWith(
+                    color: AppColors.textLight.withValues(alpha: 0.35))),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bug Report Tab
+// ---------------------------------------------------------------------------
+
+class _BugReportTab extends StatefulWidget {
+  final String? appVersion;
+  const _BugReportTab({this.appVersion});
+
+  @override
+  State<_BugReportTab> createState() => _BugReportTabState();
+}
+
+class _BugReportTabState extends State<_BugReportTab> {
+  final _titleCtrl          = TextEditingController();
+  final _givenCtrl          = TextEditingController();
+  final _whenCtrl           = TextEditingController();
+  final _thenExpectedCtrl   = TextEditingController();
+  final _butActuallyCtrl    = TextEditingController();
+  final _supportingCtrl     = TextEditingController();
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _givenCtrl.dispose();
+    _whenCtrl.dispose();
+    _thenExpectedCtrl.dispose();
+    _butActuallyCtrl.dispose();
+    _supportingCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_titleCtrl.text.trim().isEmpty ||
+        _givenCtrl.text.trim().isEmpty ||
+        _whenCtrl.text.trim().isEmpty ||
+        _thenExpectedCtrl.text.trim().isEmpty ||
+        _butActuallyCtrl.text.trim().isEmpty) {
+      _showSnack('Please fill in all required fields.');
+      return;
+    }
+    setState(() => _submitting = true);
+    final ok = await GithubIssueService.submitBugReport(
+      title: _titleCtrl.text.trim(),
+      given: _givenCtrl.text.trim(),
+      when: _whenCtrl.text.trim(),
+      thenExpected: _thenExpectedCtrl.text.trim(),
+      butActually: _butActuallyCtrl.text.trim(),
+      supportingDetails: _supportingCtrl.text.trim().isEmpty
+          ? null
+          : _supportingCtrl.text.trim(),
+      appVersion: widget.appVersion,
+    );
+    if (!mounted) return;
+    setState(() => _submitting = false);
+    if (ok) {
+      _titleCtrl.clear();
+      _givenCtrl.clear();
+      _whenCtrl.clear();
+      _thenExpectedCtrl.clear();
+      _butActuallyCtrl.clear();
+      _supportingCtrl.clear();
+    }
+    _showSnack(ok
+        ? 'Bug report submitted — thank you!'
+        : 'Could not submit — check your connection and try again.');
+  }
+
+  void _showSnack(String msg) => ScaffoldMessenger.of(context)
+      .showSnackBar(SnackBar(content: Text(msg)));
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Describe the bug using the structured fields below. '
+            'Required fields are marked *.',
+            style: tt.bodySmall?.copyWith(
+                color: AppColors.textLight.withValues(alpha: 0.7)),
+          ),
+          const SizedBox(height: 16),
+          _Field(
+            controller: _titleCtrl,
+            label: 'Title *',
+            hint: 'One-line summary (e.g. "App crashes on results screen")',
+            maxLines: 1,
+          ),
+          const SizedBox(height: 14),
+          _Field(
+            controller: _givenCtrl,
+            label: 'Given * — scenario and conditions',
+            hint: 'Describe the situation and any conditions needed to reproduce…',
+            maxLines: 4,
+          ),
+          const SizedBox(height: 14),
+          _Field(
+            controller: _whenCtrl,
+            label: 'When * — the action you took',
+            hint: 'Describe the specific action or feature you attempted…',
+            maxLines: 3,
+          ),
+          const SizedBox(height: 14),
+          _Field(
+            controller: _thenExpectedCtrl,
+            label: 'Then Expected * — what should have happened',
+            hint: 'Describe the behaviour you expected to see…',
+            maxLines: 3,
+          ),
+          const SizedBox(height: 14),
+          _Field(
+            controller: _butActuallyCtrl,
+            label: 'But Actually * — what actually happened',
+            hint: 'Describe what you observed instead…',
+            maxLines: 3,
+          ),
+          const SizedBox(height: 14),
+          _Field(
+            controller: _supportingCtrl,
+            label: 'Supporting details (optional)',
+            hint: 'Any extra context, error messages, or steps to reproduce consistently…',
+            maxLines: 4,
+          ),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: _submitting ? null : _submit,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.dangerRed,
+                foregroundColor: AppColors.textLight,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              icon: _submitting
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(
+                          strokeWidth: 2, color: AppColors.textLight))
+                  : const Icon(Icons.bug_report),
+              label: Text(_submitting ? 'Submitting…' : 'Submit Bug Report',
                   style: const TextStyle(fontWeight: FontWeight.bold)),
             ),
           ),

--- a/lib/features/feedback/presentation/screens/feedback_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_screen.dart
@@ -4,6 +4,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import '../../../../core/theme/app_theme.dart';
 import '../../../gameplay/data/topic_registry.dart';
+import '../../../settings/data/user_profile_service.dart';
 import '../../data/github_issue_service.dart';
 
 class FeedbackScreen extends StatefulWidget {
@@ -17,6 +18,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _tabs;
   String? _appVersion;
+  String? _userId;
 
   @override
   void initState() {
@@ -24,6 +26,9 @@ class _FeedbackScreenState extends State<FeedbackScreen>
     _tabs = TabController(length: 2, vsync: this);
     PackageInfo.fromPlatform().then((i) {
       if (mounted) setState(() => _appVersion = '${i.version}+${i.buildNumber}');
+    });
+    UserProfileService.getUserId().then((id) {
+      if (mounted) setState(() => _userId = id);
     });
   }
 
@@ -54,8 +59,8 @@ class _FeedbackScreenState extends State<FeedbackScreen>
       body: TabBarView(
         controller: _tabs,
         children: [
-          _GeneralFeedbackTab(appVersion: _appVersion),
-          _ContentRequestTab(appVersion: _appVersion),
+          _GeneralFeedbackTab(appVersion: _appVersion, userId: _userId),
+          _ContentRequestTab(appVersion: _appVersion, userId: _userId),
         ],
       ),
     );
@@ -68,7 +73,8 @@ class _FeedbackScreenState extends State<FeedbackScreen>
 
 class _GeneralFeedbackTab extends StatefulWidget {
   final String? appVersion;
-  const _GeneralFeedbackTab({this.appVersion});
+  final String? userId;
+  const _GeneralFeedbackTab({this.appVersion, this.userId});
 
   @override
   State<_GeneralFeedbackTab> createState() => _GeneralFeedbackTabState();
@@ -98,6 +104,7 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
       title: _titleCtrl.text.trim(),
       body: _bodyCtrl.text.trim(),
       appVersion: widget.appVersion,
+      userId: widget.userId,
     );
     if (!mounted) return;
     setState(() => _submitting = false);
@@ -153,7 +160,8 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
             controller: _bodyCtrl,
             label: 'Details',
             hint: 'Describe the issue or idea in as much detail as you like…',
-            maxLines: 6,
+            minLines: 6,
+            maxLines: null,
           ),
           const SizedBox(height: 24),
           SizedBox(
@@ -191,7 +199,8 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
 
 class _ContentRequestTab extends StatefulWidget {
   final String? appVersion;
-  const _ContentRequestTab({this.appVersion});
+  final String? userId;
+  const _ContentRequestTab({this.appVersion, this.userId});
 
   @override
   State<_ContentRequestTab> createState() => _ContentRequestTabState();
@@ -229,6 +238,7 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
           : _bodyCtrl.text.trim(),
       topicId: _selectedTopicId,
       appVersion: widget.appVersion,
+      userId: widget.userId,
     );
     if (!mounted) return;
     setState(() => _submitting = false);
@@ -293,7 +303,8 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
               controller: _bodyCtrl,
               label: 'Why this topic? (optional)',
               hint: 'Tell us why you\'d love to see this topic in the game…',
-              maxLines: 4,
+              minLines: 4,
+              maxLines: null,
             ),
           ] else ...[
             Text('Which topic?', style: tt.labelLarge?.copyWith(color: AppColors.textLight)),
@@ -333,7 +344,8 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
               controller: _bodyCtrl,
               label: 'Additional notes (optional)',
               hint: 'Any specific questions or areas to cover?',
-              maxLines: 4,
+              minLines: 4,
+              maxLines: null,
             ),
           ],
 
@@ -369,13 +381,16 @@ class _Field extends StatelessWidget {
   final TextEditingController controller;
   final String label;
   final String hint;
-  final int maxLines;
+  final int minLines;
+  // null = unbounded (expands with content, avoids internal scroll conflicts)
+  final int? maxLines;
 
   const _Field({
     required this.controller,
     required this.label,
     required this.hint,
-    required this.maxLines,
+    this.minLines = 1,
+    this.maxLines = 1,
   });
 
   @override
@@ -391,6 +406,7 @@ class _Field extends StatelessWidget {
         const SizedBox(height: 6),
         TextField(
           controller: controller,
+          minLines: minLines,
           maxLines: maxLines,
           style: const TextStyle(color: AppColors.textLight),
           decoration: InputDecoration(

--- a/lib/features/feedback/presentation/screens/feedback_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_screen.dart
@@ -4,7 +4,12 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import '../../../../core/theme/app_theme.dart';
 import '../../../gameplay/data/topic_registry.dart';
+import '../../data/feedback_draft_repository.dart';
 import '../../data/github_issue_service.dart';
+
+// Tab indices
+const _kTabGeneral  = 0;
+const _kTabContent  = 1;
 
 class FeedbackScreen extends StatefulWidget {
   const FeedbackScreen({super.key});
@@ -18,10 +23,17 @@ class _FeedbackScreenState extends State<FeedbackScreen>
   late final TabController _tabs;
   String? _appVersion;
 
+  /// Incremented whenever a draft is saved or deleted, triggering the
+  /// Pending tab to reload.
+  int _draftRevision = 0;
+
+  /// Non-null while a draft is being loaded into an input tab.
+  FeedbackDraft? _loadedDraft;
+
   @override
   void initState() {
     super.initState();
-    _tabs = TabController(length: 2, vsync: this);
+    _tabs = TabController(length: 3, vsync: this);
     PackageInfo.fromPlatform().then((i) {
       if (mounted) setState(() => _appVersion = '${i.version}+${i.buildNumber}');
     });
@@ -31,6 +43,17 @@ class _FeedbackScreenState extends State<FeedbackScreen>
   void dispose() {
     _tabs.dispose();
     super.dispose();
+  }
+
+  void _onDraftSaved() => setState(() => _draftRevision++);
+
+  void _onDraftLoaded() => setState(() => _loadedDraft = null);
+
+  void _loadDraft(FeedbackDraft draft) {
+    setState(() => _loadedDraft = draft);
+    _tabs.animateTo(
+      draft.type == 'general' ? _kTabGeneral : _kTabContent,
+    );
   }
 
   @override
@@ -47,15 +70,31 @@ class _FeedbackScreenState extends State<FeedbackScreen>
           unselectedLabelColor: AppColors.textLight,
           tabs: const [
             Tab(icon: Icon(Icons.chat_bubble_outline), text: 'General'),
-            Tab(icon: Icon(Icons.library_add_outlined), text: 'Content Request'),
+            Tab(icon: Icon(Icons.library_add_outlined), text: 'Content'),
+            Tab(icon: Icon(Icons.pending_actions_outlined), text: 'Pending'),
           ],
         ),
       ),
       body: TabBarView(
         controller: _tabs,
         children: [
-          _GeneralFeedbackTab(appVersion: _appVersion),
-          _ContentRequestTab(appVersion: _appVersion),
+          _GeneralFeedbackTab(
+            appVersion: _appVersion,
+            loadedDraft: _loadedDraft?.type == 'general' ? _loadedDraft : null,
+            onDraftLoaded: _onDraftLoaded,
+            onDraftSaved: _onDraftSaved,
+          ),
+          _ContentRequestTab(
+            appVersion: _appVersion,
+            loadedDraft: _loadedDraft?.type == 'content' ? _loadedDraft : null,
+            onDraftLoaded: _onDraftLoaded,
+            onDraftSaved: _onDraftSaved,
+          ),
+          _PendingFeedbackTab(
+            draftRevision: _draftRevision,
+            onLoadDraft: _loadDraft,
+            onDraftDeleted: _onDraftSaved,
+          ),
         ],
       ),
     );
@@ -68,7 +107,16 @@ class _FeedbackScreenState extends State<FeedbackScreen>
 
 class _GeneralFeedbackTab extends StatefulWidget {
   final String? appVersion;
-  const _GeneralFeedbackTab({this.appVersion});
+  final FeedbackDraft? loadedDraft;
+  final VoidCallback onDraftLoaded;
+  final VoidCallback onDraftSaved;
+
+  const _GeneralFeedbackTab({
+    this.appVersion,
+    this.loadedDraft,
+    required this.onDraftLoaded,
+    required this.onDraftSaved,
+  });
 
   @override
   State<_GeneralFeedbackTab> createState() => _GeneralFeedbackTabState();
@@ -79,6 +127,25 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
   final _titleCtrl = TextEditingController();
   final _bodyCtrl  = TextEditingController();
   bool _submitting = false;
+  final _repo = FeedbackDraftRepository();
+
+  @override
+  void didUpdateWidget(_GeneralFeedbackTab old) {
+    super.didUpdateWidget(old);
+    final draft = widget.loadedDraft;
+    if (draft != null && draft != old.loadedDraft) {
+      _titleCtrl.text = draft.fields[FeedbackDraft.fieldTitle] ?? '';
+      _bodyCtrl.text  = draft.fields[FeedbackDraft.fieldBody] ?? '';
+      final catName   = draft.fields[FeedbackDraft.fieldCategory];
+      if (catName != null) {
+        final cat = FeedbackCategory.values
+            .where((c) => c.name == catName)
+            .firstOrNull;
+        if (cat != null) setState(() => _category = cat);
+      }
+      widget.onDraftLoaded();
+    }
+  }
 
   @override
   void dispose() {
@@ -108,6 +175,28 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
     _showSnack(ok
         ? 'Thank you! Your feedback has been submitted.'
         : 'Could not submit — check your connection and try again.');
+  }
+
+  Future<void> _saveDraft() async {
+    if (_titleCtrl.text.trim().isEmpty && _bodyCtrl.text.trim().isEmpty) {
+      _showSnack('Nothing to save — fill in at least one field.');
+      return;
+    }
+    final draft = FeedbackDraft(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      type: 'general',
+      fields: {
+        FeedbackDraft.fieldTitle:    _titleCtrl.text,
+        FeedbackDraft.fieldBody:     _bodyCtrl.text,
+        FeedbackDraft.fieldCategory: _category.name,
+      },
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+    await _repo.save(draft);
+    if (!mounted) return;
+    widget.onDraftSaved();
+    _showSnack('Draft saved — find it in the Pending tab.');
   }
 
   void _showSnack(String msg) => ScaffoldMessenger.of(context)
@@ -153,25 +242,42 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
             controller: _bodyCtrl,
             label: 'Details',
             hint: 'Describe the issue or idea in as much detail as you like…',
-            maxLines: 6,
+            minLines: 6,
+            maxLines: null,
           ),
           const SizedBox(height: 24),
-          SizedBox(
-            width: double.infinity,
-            child: ElevatedButton.icon(
-              onPressed: _submitting ? null : _submit,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.torchAmber,
-                foregroundColor: AppColors.textDark,
-                padding: const EdgeInsets.symmetric(vertical: 14),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: _saveDraft,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: AppColors.textLight,
+                    side: const BorderSide(color: AppColors.stoneMid),
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  icon: const Icon(Icons.save_outlined, size: 18),
+                  label: const Text('Save Draft'),
+                ),
               ),
-              icon: _submitting
-                  ? const SizedBox(width: 18, height: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2, color: AppColors.textDark))
-                  : const Icon(Icons.send),
-              label: Text(_submitting ? 'Submitting…' : 'Submit Feedback',
-                  style: const TextStyle(fontWeight: FontWeight.bold)),
-            ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton.icon(
+                  onPressed: _submitting ? null : _submit,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.torchAmber,
+                    foregroundColor: AppColors.textDark,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  icon: _submitting
+                      ? const SizedBox(width: 18, height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2, color: AppColors.textDark))
+                      : const Icon(Icons.send),
+                  label: Text(_submitting ? 'Submitting…' : 'Submit',
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
+                ),
+              ),
+            ],
           ),
           if (widget.appVersion != null) ...[
             const SizedBox(height: 12),
@@ -191,7 +297,16 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
 
 class _ContentRequestTab extends StatefulWidget {
   final String? appVersion;
-  const _ContentRequestTab({this.appVersion});
+  final FeedbackDraft? loadedDraft;
+  final VoidCallback onDraftLoaded;
+  final VoidCallback onDraftSaved;
+
+  const _ContentRequestTab({
+    this.appVersion,
+    this.loadedDraft,
+    required this.onDraftLoaded,
+    required this.onDraftSaved,
+  });
 
   @override
   State<_ContentRequestTab> createState() => _ContentRequestTabState();
@@ -203,6 +318,26 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
   final _titleCtrl = TextEditingController();
   final _bodyCtrl  = TextEditingController();
   bool _submitting = false;
+  final _repo = FeedbackDraftRepository();
+
+  @override
+  void didUpdateWidget(_ContentRequestTab old) {
+    super.didUpdateWidget(old);
+    final draft = widget.loadedDraft;
+    if (draft != null && draft != old.loadedDraft) {
+      _titleCtrl.text     = draft.fields[FeedbackDraft.fieldTitle] ?? '';
+      _bodyCtrl.text      = draft.fields[FeedbackDraft.fieldBody] ?? '';
+      _selectedTopicId    = draft.fields[FeedbackDraft.fieldTopicId];
+      final rtName        = draft.fields[FeedbackDraft.fieldRequestType];
+      if (rtName != null) {
+        final rt = ContentRequestType.values
+            .where((t) => t.name == rtName)
+            .firstOrNull;
+        if (rt != null) setState(() => _type = rt);
+      }
+      widget.onDraftLoaded();
+    }
+  }
 
   @override
   void dispose() {
@@ -242,13 +377,36 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
         : 'Could not submit — check your connection and try again.');
   }
 
+  Future<void> _saveDraft() async {
+    if (_titleCtrl.text.trim().isEmpty) {
+      _showSnack('Nothing to save — fill in at least a title.');
+      return;
+    }
+    final draft = FeedbackDraft(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      type: 'content',
+      fields: {
+        FeedbackDraft.fieldRequestType: _type.name,
+        FeedbackDraft.fieldTitle:        _titleCtrl.text,
+        FeedbackDraft.fieldBody:         _bodyCtrl.text,
+        if (_selectedTopicId != null)
+          FeedbackDraft.fieldTopicId: _selectedTopicId!,
+      },
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+    await _repo.save(draft);
+    if (!mounted) return;
+    widget.onDraftSaved();
+    _showSnack('Draft saved — find it in the Pending tab.');
+  }
+
   void _showSnack(String msg) => ScaffoldMessenger.of(context)
       .showSnackBar(SnackBar(content: Text(msg)));
 
   @override
   Widget build(BuildContext context) {
     final tt = Theme.of(context).textTheme;
-    // Flat list of all topics for the picker
     final allTopics = superCategories
         .expand((sc) => sc.categories.expand((c) => c.topics))
         .toList();
@@ -293,7 +451,8 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
               controller: _bodyCtrl,
               label: 'Why this topic? (optional)',
               hint: 'Tell us why you\'d love to see this topic in the game…',
-              maxLines: 4,
+              minLines: 4,
+              maxLines: null,
             ),
           ] else ...[
             Text('Which topic?', style: tt.labelLarge?.copyWith(color: AppColors.textLight)),
@@ -333,31 +492,198 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
               controller: _bodyCtrl,
               label: 'Additional notes (optional)',
               hint: 'Any specific questions or areas to cover?',
-              maxLines: 4,
+              minLines: 4,
+              maxLines: null,
             ),
           ],
 
           const SizedBox(height: 24),
-          SizedBox(
-            width: double.infinity,
-            child: ElevatedButton.icon(
-              onPressed: _submitting ? null : _submit,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.torchAmber,
-                foregroundColor: AppColors.textDark,
-                padding: const EdgeInsets.symmetric(vertical: 14),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: _saveDraft,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: AppColors.textLight,
+                    side: const BorderSide(color: AppColors.stoneMid),
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  icon: const Icon(Icons.save_outlined, size: 18),
+                  label: const Text('Save Draft'),
+                ),
               ),
-              icon: _submitting
-                  ? const SizedBox(width: 18, height: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2, color: AppColors.textDark))
-                  : const Icon(Icons.send),
-              label: Text(_submitting ? 'Submitting…' : 'Submit Request',
-                  style: const TextStyle(fontWeight: FontWeight.bold)),
-            ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton.icon(
+                  onPressed: _submitting ? null : _submit,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.torchAmber,
+                    foregroundColor: AppColors.textDark,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  icon: _submitting
+                      ? const SizedBox(width: 18, height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2, color: AppColors.textDark))
+                      : const Icon(Icons.send),
+                  label: Text(_submitting ? 'Submitting…' : 'Submit',
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
+                ),
+              ),
+            ],
           ),
         ],
       ),
     );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pending Feedback Tab
+// ---------------------------------------------------------------------------
+
+class _PendingFeedbackTab extends StatefulWidget {
+  final int draftRevision;
+  final void Function(FeedbackDraft) onLoadDraft;
+  final VoidCallback onDraftDeleted;
+
+  const _PendingFeedbackTab({
+    required this.draftRevision,
+    required this.onLoadDraft,
+    required this.onDraftDeleted,
+  });
+
+  @override
+  State<_PendingFeedbackTab> createState() => _PendingFeedbackTabState();
+}
+
+class _PendingFeedbackTabState extends State<_PendingFeedbackTab> {
+  final _repo = FeedbackDraftRepository();
+  late Future<List<FeedbackDraft>> _draftsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _draftsFuture = _repo.loadAll();
+  }
+
+  @override
+  void didUpdateWidget(_PendingFeedbackTab old) {
+    super.didUpdateWidget(old);
+    if (widget.draftRevision != old.draftRevision) {
+      setState(() => _draftsFuture = _repo.loadAll());
+    }
+  }
+
+  Future<void> _delete(String id) async {
+    await _repo.delete(id);
+    widget.onDraftDeleted();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<FeedbackDraft>>(
+      future: _draftsFuture,
+      builder: (context, snap) {
+        if (snap.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final drafts = snap.data ?? [];
+        if (drafts.isEmpty) {
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.pending_actions_outlined,
+                      size: 48,
+                      color: AppColors.textLight.withValues(alpha: 0.3)),
+                  const SizedBox(height: 16),
+                  Text(
+                    'No pending feedback',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: AppColors.textLight.withValues(alpha: 0.5)),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Use "Save Draft" on the General or Content tab to save '
+                    'feedback before sending.',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: AppColors.textLight.withValues(alpha: 0.35)),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+        return ListView.separated(
+          padding: const EdgeInsets.all(16),
+          itemCount: drafts.length,
+          separatorBuilder: (_, __) => const SizedBox(height: 8),
+          itemBuilder: (context, i) {
+            final draft = drafts[i];
+            final typeLabel =
+                draft.type == 'general' ? '💬 General' : '📚 Content';
+            final updated = _formatRelative(draft.updatedAt);
+            return Card(
+              color: AppColors.stone,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8)),
+              child: InkWell(
+                borderRadius: BorderRadius.circular(8),
+                onTap: () => widget.onLoadDraft(draft),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16, vertical: 12),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              draft.displayTitle,
+                              style: const TextStyle(
+                                  color: AppColors.parchment,
+                                  fontWeight: FontWeight.w600),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              '$typeLabel · $updated',
+                              style: TextStyle(
+                                  color:
+                                      AppColors.textLight.withValues(alpha: 0.55),
+                                  fontSize: 12),
+                            ),
+                          ],
+                        ),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.delete_outline,
+                            color: AppColors.dangerRed, size: 20),
+                        tooltip: 'Discard draft',
+                        onPressed: () => _delete(draft.id),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  String _formatRelative(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inMinutes < 1) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
   }
 }
 
@@ -369,13 +695,16 @@ class _Field extends StatelessWidget {
   final TextEditingController controller;
   final String label;
   final String hint;
-  final int maxLines;
+  final int minLines;
+  // null = unbounded (expands with content, avoids internal scroll conflicts)
+  final int? maxLines;
 
   const _Field({
     required this.controller,
     required this.label,
     required this.hint,
-    required this.maxLines,
+    this.minLines = 1,
+    this.maxLines = 1,
   });
 
   @override
@@ -391,6 +720,7 @@ class _Field extends StatelessWidget {
         const SizedBox(height: 6),
         TextField(
           controller: controller,
+          minLines: minLines,
           maxLines: maxLines,
           style: const TextStyle(color: AppColors.textLight),
           decoration: InputDecoration(

--- a/lib/features/settings/data/user_profile_service.dart
+++ b/lib/features/settings/data/user_profile_service.dart
@@ -1,0 +1,29 @@
+import 'dart:math';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Manages a stable, anonymous local user identifier.
+///
+/// The ID is generated once on first use (`usr_` + 12 random hex characters)
+/// and persisted in shared_preferences. It is attached to all feedback
+/// submissions so reports from the same tester can be grouped without
+/// requiring an account.
+class UserProfileService {
+  static const _key = 'user_profile_id';
+
+  /// Returns the stored user ID, generating one if none exists yet.
+  static Future<String> getUserId() async {
+    final prefs = await SharedPreferences.getInstance();
+    var id = prefs.getString(_key);
+    if (id == null || id.isEmpty) {
+      id = _generateId();
+      await prefs.setString(_key, id);
+    }
+    return id;
+  }
+
+  static String _generateId() {
+    final rand = Random.secure();
+    final hex = List.generate(12, (_) => rand.nextInt(16).toRadixString(16)).join();
+    return 'usr_$hex';
+  }
+}

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -1,0 +1,383 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../feedback/data/github_issue_service.dart';
+import '../../data/user_profile_service.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  String? _userId;
+  String? _appVersion;
+  late Future<List<IssueItem>> _issuesFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _issuesFuture = GithubIssueService.fetchOpenIssues();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final results = await Future.wait([
+      UserProfileService.getUserId(),
+      PackageInfo.fromPlatform().then((i) => '${i.version}+${i.buildNumber}'),
+    ]);
+    if (!mounted) return;
+    setState(() {
+      _userId     = results[0];
+      _appVersion = results[1];
+    });
+  }
+
+  void _copyUserId() {
+    if (_userId == null) return;
+    Clipboard.setData(ClipboardData(text: _userId!));
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('User ID copied to clipboard')),
+    );
+  }
+
+  void _showAddComment(IssueItem issue) {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: AppColors.stoneDark,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(16))),
+      builder: (ctx) => _AddCommentSheet(
+        issue: issue,
+        userId: _userId,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.stoneDark,
+        title: const Text('Settings'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        children: [
+          // ── Profile ──────────────────────────────────────────────────────
+          const _SectionHeader('Profile'),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Card(
+              color: AppColors.stone,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8)),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Anonymous tester ID',
+                      style: tt.labelMedium?.copyWith(color: AppColors.parchment),
+                    ),
+                    const SizedBox(height: 6),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            _userId ?? '…',
+                            style: tt.bodyMedium?.copyWith(
+                              color: AppColors.torchAmber,
+                              fontFamily: 'monospace',
+                              letterSpacing: 1,
+                            ),
+                          ),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.copy_outlined,
+                              size: 18, color: AppColors.torchAmber),
+                          tooltip: 'Copy ID',
+                          onPressed: _copyUserId,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'This ID is stored only on your device and is attached '
+                      'to all feedback you submit.',
+                      style: tt.bodySmall?.copyWith(
+                          color: AppColors.textLight.withValues(alpha: 0.5)),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+          // ── Feedback ─────────────────────────────────────────────────────
+          const _SectionHeader('Feedback'),
+          ListTile(
+            leading: const Icon(Icons.feedback_outlined,
+                color: AppColors.torchAmber),
+            title: const Text('Give Feedback',
+                style: TextStyle(color: AppColors.textLight)),
+            subtitle: Text(
+              'Report a bug, request a feature, or suggest content',
+              style: tt.bodySmall?.copyWith(
+                  color: AppColors.textLight.withValues(alpha: 0.5)),
+            ),
+            trailing: const Icon(Icons.chevron_right,
+                color: AppColors.stoneMid),
+            onTap: () => context.push('/feedback'),
+          ),
+
+          // ── Open Issues ──────────────────────────────────────────────────
+          const _SectionHeader('Open Issues'),
+          FutureBuilder<List<IssueItem>>(
+            future: _issuesFuture,
+            builder: (context, snap) {
+              if (snap.connectionState != ConnectionState.done) {
+                return const Padding(
+                  padding: EdgeInsets.all(24),
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              }
+              final issues = snap.data ?? [];
+              if (issues.isEmpty) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16, vertical: 12),
+                  child: Text(
+                    'No open issues — or unable to reach GitHub.',
+                    style: tt.bodySmall?.copyWith(
+                        color: AppColors.textLight.withValues(alpha: 0.4)),
+                  ),
+                );
+              }
+              return Column(
+                children: issues.map((issue) {
+                  return ListTile(
+                    leading: CircleAvatar(
+                      backgroundColor: AppColors.stone,
+                      radius: 16,
+                      child: Text(
+                        '#${issue.number}',
+                        style: const TextStyle(
+                            color: AppColors.torchAmber,
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    title: Text(
+                      issue.title,
+                      style: const TextStyle(
+                          color: AppColors.textLight, fontSize: 13),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    subtitle: issue.labelNames.isNotEmpty
+                        ? Text(
+                            issue.labelNames.join(' · '),
+                            style: TextStyle(
+                                color: AppColors.textLight.withValues(alpha: 0.45),
+                                fontSize: 11),
+                          )
+                        : null,
+                    trailing: TextButton(
+                      onPressed: () => _showAddComment(issue),
+                      style: TextButton.styleFrom(
+                          foregroundColor: AppColors.torchAmber),
+                      child: const Text('Comment',
+                          style: TextStyle(fontSize: 12)),
+                    ),
+                    contentPadding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+                  );
+                }).toList(),
+              );
+            },
+          ),
+
+          // ── App ──────────────────────────────────────────────────────────
+          const _SectionHeader('App'),
+          ListTile(
+            leading: const Icon(Icons.info_outline, color: AppColors.stoneMid),
+            title: const Text('Version',
+                style: TextStyle(color: AppColors.textLight)),
+            trailing: Text(
+              _appVersion ?? '…',
+              style: tt.bodySmall?.copyWith(
+                  color: AppColors.textLight.withValues(alpha: 0.5)),
+            ),
+          ),
+
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section header
+// ---------------------------------------------------------------------------
+
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  const _SectionHeader(this.title);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 4),
+      child: Text(
+        title.toUpperCase(),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: AppColors.torchAmber.withValues(alpha: 0.7),
+              letterSpacing: 1.2,
+            ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Add comment bottom sheet
+// ---------------------------------------------------------------------------
+
+class _AddCommentSheet extends StatefulWidget {
+  final IssueItem issue;
+  final String? userId;
+
+  const _AddCommentSheet({required this.issue, this.userId});
+
+  @override
+  State<_AddCommentSheet> createState() => _AddCommentSheetState();
+}
+
+class _AddCommentSheetState extends State<_AddCommentSheet> {
+  final _ctrl = TextEditingController();
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_ctrl.text.trim().isEmpty) return;
+    setState(() => _submitting = true);
+    final ok = await GithubIssueService.addComment(
+      issueNumber: widget.issue.number,
+      body: _ctrl.text.trim(),
+      userId: widget.userId,
+    );
+    if (!mounted) return;
+    setState(() => _submitting = false);
+    if (ok) {
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Comment added — thank you!')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content:
+                Text('Could not submit — check your connection and try again.')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+        left: 20,
+        right: 20,
+        top: 20,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Add comment to #${widget.issue.number}',
+            style: tt.titleSmall?.copyWith(color: AppColors.parchment),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            widget.issue.title,
+            style: tt.bodySmall?.copyWith(
+                color: AppColors.textLight.withValues(alpha: 0.55)),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _ctrl,
+            minLines: 3,
+            maxLines: null,
+            autofocus: true,
+            style: const TextStyle(color: AppColors.textLight),
+            decoration: InputDecoration(
+              hintText: 'Add any additional context, updates, or follow-up…',
+              hintStyle: TextStyle(
+                  color: AppColors.textLight.withValues(alpha: 0.4),
+                  fontSize: 13),
+              filled: true,
+              fillColor: AppColors.stone,
+              border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: const BorderSide(color: AppColors.stoneMid)),
+              enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: BorderSide(
+                      color: AppColors.stoneMid.withValues(alpha: 0.6))),
+              focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: const BorderSide(
+                      color: AppColors.torchAmber, width: 1.5)),
+              contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 12, vertical: 10),
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: _submitting ? null : _submit,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.torchAmber,
+                foregroundColor: AppColors.textDark,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              icon: _submitting
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(
+                          strokeWidth: 2, color: AppColors.textDark))
+                  : const Icon(Icons.comment_outlined),
+              label: Text(_submitting ? 'Submitting…' : 'Submit Comment',
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
+            ),
+          ),
+          const SizedBox(height: 20),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/start/presentation/screens/start_screen.dart
+++ b/lib/features/start/presentation/screens/start_screen.dart
@@ -125,13 +125,13 @@ class StartScreen extends ConsumerWidget {
 
                     const SizedBox(height: 4),
 
-                    // Feedback button
+                    // Settings button (feedback + issues accessible from there)
                     TextButton.icon(
-                      onPressed: () => context.push('/feedback'),
-                      icon: Icon(Icons.feedback_outlined,
+                      onPressed: () => context.push('/settings'),
+                      icon: Icon(Icons.settings_outlined,
                           size: 18,
                           color: AppColors.textLight.withValues(alpha: 0.55)),
-                      label: Text('Feedback',
+                      label: Text('Settings',
                           style: textTheme.labelMedium?.copyWith(
                               color: AppColors.textLight
                                   .withValues(alpha: 0.55))),

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Features
+- Save feedback as a draft before sending — new "Pending" tab in Feedback lists saved drafts; tap to reload into the form, swipe or tap the delete icon to discard (#49)
 - Auto-check for app updates on launch — update dialog appears automatically when a new version is available
 - In-app update dialog now renders release notes as formatted markdown with full scrollable content
 - Download button now triggers a direct APK download instead of opening the browser release page

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Features
+- Settings page — new screen accessible from the start screen with user profile, feedback, open issues, and app info (#45)
+- Anonymous tester ID — generated locally on first launch and attached to all feedback submissions for grouping without accounts (#45)
+- Comment on open issues — view active alpha-feedback issues in Settings and add follow-up comments directly from the app (#45)
 - Auto-check for app updates on launch — update dialog appears automatically when a new version is available
 - In-app update dialog now renders release notes as formatted markdown with full scrollable content
 - Download button now triggers a direct APK download instead of opening the browser release page

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Features
+- Structured bug report form — new "Bug Report" tab in Feedback with Given / When / Then Expected / But Actually fields for clearer, actionable reports (#48)
 - Auto-check for app updates on launch — update dialog appears automatically when a new version is available
 - In-app update dialog now renders release notes as formatted markdown with full scrollable content
 - Download button now triggers a direct APK download instead of opening the browser release page


### PR DESCRIPTION
Closes #45
Closes #48
Closes #49

Three feedback improvements landed together on `dev`, verified clean before merging to `main`.

## What's included

- **#48** — Structured bug report tab: new "Bug Report" tab in Feedback with Given / When / Then Expected / But Actually fields for clearer, actionable reports
- **#49** — Save feedback as draft: new "Pending" tab lists saved drafts; tap to reload into the form, delete icon to discard
- **#45** — Settings page: new screen from the start screen with local anonymous tester ID, Give Feedback shortcut, and open alpha-feedback issues list with in-app comment support

## Test plan
- [ ] `flutter analyze --fatal-infos` passes ✅
- [ ] `flutter test` passes ✅ (53 tests, 0 failures)
- [ ] Manual: open app → tap Settings → confirm user ID shown, feedback link works, open issues load
- [ ] Manual: Feedback → General tab → fill fields → Save Draft → Pending tab shows draft → tap to reload
- [ ] Manual: Feedback → Bug Report tab → fill all required fields → Submit