### PR TITLE
fix: issue descriptions/comments not viewable + duplicate Bug Report chip (#77, #75)

### DIFF
--- a/lib/features/feedback/data/github_issue_service.dart
+++ b/lib/features/feedback/data/github_issue_service.dart
@@ -32,12 +32,14 @@ enum ContentRequestType {
 class IssueItem {
   final int number;
   final String title;
+  final String body;
   final List<String> labelNames;
   final DateTime createdAt;
 
   const IssueItem({
     required this.number,
     required this.title,
+    required this.body,
     required this.labelNames,
     required this.createdAt,
   });
@@ -45,9 +47,32 @@ class IssueItem {
   factory IssueItem.fromJson(Map<String, dynamic> json) => IssueItem(
         number: json['number'] as int,
         title: json['title'] as String,
+        body: (json['body'] as String?) ?? '',
         labelNames: (json['labels'] as List)
             .map((l) => l['name'] as String)
             .toList(),
+        createdAt: DateTime.parse(json['created_at'] as String),
+      );
+}
+
+/// A single comment on a GitHub issue.
+class IssueComment {
+  final int id;
+  final String body;
+  final String authorLogin;
+  final DateTime createdAt;
+
+  const IssueComment({
+    required this.id,
+    required this.body,
+    required this.authorLogin,
+    required this.createdAt,
+  });
+
+  factory IssueComment.fromJson(Map<String, dynamic> json) => IssueComment(
+        id: json['id'] as int,
+        body: (json['body'] as String?) ?? '',
+        authorLogin: (json['user'] as Map<String, dynamic>)['login'] as String,
         createdAt: DateTime.parse(json['created_at'] as String),
       );
 }
@@ -152,6 +177,27 @@ ${userId != null ? '**User ID:** `$userId`\n' : ''}**Source:** In-app content re
       final list = jsonDecode(response.body) as List;
       return list
           .map((j) => IssueItem.fromJson(j as Map<String, dynamic>))
+          .toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// Fetches comments for a single issue (most recent last).
+  static Future<List<IssueComment>> fetchIssueComments(int issueNumber) async {
+    if (_kGithubToken.isEmpty) return [];
+    try {
+      final uri = Uri.parse(
+        'https://api.github.com/repos/$_kRepoOwner/$_kRepoName/issues/$issueNumber/comments'
+        '?per_page=50&sort=created&direction=asc',
+      );
+      final response = await _client
+          .get(uri, headers: _headers)
+          .timeout(const Duration(seconds: 15));
+      if (response.statusCode != 200) return [];
+      final list = jsonDecode(response.body) as List;
+      return list
+          .map((j) => IssueComment.fromJson(j as Map<String, dynamic>))
           .toList();
     } catch (_) {
       return [];

--- a/lib/features/feedback/presentation/screens/feedback_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_screen.dart
@@ -230,7 +230,7 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
           Wrap(
             spacing: 8,
             runSpacing: 8,
-            children: FeedbackCategory.values.map((c) {
+            children: FeedbackCategory.values.where((c) => c != FeedbackCategory.bug).map((c) {
               final selected = _category == c;
               return ChoiceChip(
                 label: Text('${c.emoji} ${c.label}'),

--- a/lib/features/feedback/presentation/screens/feedback_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_screen.dart
@@ -11,7 +11,7 @@ import '../../data/github_issue_service.dart';
 // Tab indices
 const _kTabGeneral  = 0;
 const _kTabContent  = 2;
-const _kTabIssues   = 4;
+
 
 class FeedbackScreen extends StatefulWidget {
   const FeedbackScreen({super.key});

--- a/lib/features/feedback/presentation/screens/feedback_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_screen.dart
@@ -11,6 +11,7 @@ import '../../data/github_issue_service.dart';
 // Tab indices
 const _kTabGeneral  = 0;
 const _kTabContent  = 2;
+const _kTabIssues   = 4;
 
 class FeedbackScreen extends StatefulWidget {
   const FeedbackScreen({super.key});
@@ -35,7 +36,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
   @override
   void initState() {
     super.initState();
-    _tabs = TabController(length: 4, vsync: this);
+    _tabs = TabController(length: 5, vsync: this);
     PackageInfo.fromPlatform().then((i) {
       if (mounted) setState(() => _appVersion = '${i.version}+${i.buildNumber}');
     });
@@ -78,6 +79,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
             Tab(icon: Icon(Icons.bug_report_outlined), text: 'Bug Report'),
             Tab(icon: Icon(Icons.library_add_outlined), text: 'Content'),
             Tab(icon: Icon(Icons.pending_actions_outlined), text: 'Pending'),
+            Tab(icon: Icon(Icons.list_alt_outlined), text: 'Issues'),
           ],
         ),
       ),
@@ -104,6 +106,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
             onLoadDraft: _loadDraft,
             onDraftDeleted: _onDraftSaved,
           ),
+          _IssuesTab(userId: _userId),
         ],
       ),
     );
@@ -859,6 +862,460 @@ class _PendingFeedbackTabState extends State<_PendingFeedbackTab> {
     if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
     if (diff.inHours < 24) return '${diff.inHours}h ago';
     return '${diff.inDays}d ago';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Issues Tab
+// ---------------------------------------------------------------------------
+
+class _IssuesTab extends StatefulWidget {
+  final String? userId;
+  const _IssuesTab({this.userId});
+
+  @override
+  State<_IssuesTab> createState() => _IssuesTabState();
+}
+
+class _IssuesTabState extends State<_IssuesTab>
+    with AutomaticKeepAliveClientMixin {
+  late Future<List<IssueItem>> _issuesFuture;
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    _issuesFuture = GithubIssueService.fetchOpenIssues();
+  }
+
+  void _openDetail(IssueItem issue) {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: AppColors.stoneDark,
+      isScrollControlled: true,
+      useSafeArea: true,
+      shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(16))),
+      builder: (ctx) => _IssueDetailSheet(issue: issue, userId: widget.userId),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    final tt = Theme.of(context).textTheme;
+    return FutureBuilder<List<IssueItem>>(
+      future: _issuesFuture,
+      builder: (context, snap) {
+        if (snap.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final issues = snap.data ?? [];
+        if (issues.isEmpty) {
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.list_alt_outlined,
+                      size: 48,
+                      color: AppColors.textLight.withValues(alpha: 0.3)),
+                  const SizedBox(height: 16),
+                  Text(
+                    'No open issues',
+                    style: tt.titleMedium?.copyWith(
+                        color: AppColors.textLight.withValues(alpha: 0.5)),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'No open alpha-feedback issues found, or unable to reach GitHub.',
+                    textAlign: TextAlign.center,
+                    style: tt.bodySmall?.copyWith(
+                        color: AppColors.textLight.withValues(alpha: 0.35)),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+        return ListView.separated(
+          padding: const EdgeInsets.all(16),
+          itemCount: issues.length,
+          separatorBuilder: (_, __) => const Divider(
+              color: AppColors.stoneMid, height: 1, indent: 56),
+          itemBuilder: (context, i) {
+            final issue = issues[i];
+            return ListTile(
+              leading: CircleAvatar(
+                backgroundColor: AppColors.stone,
+                radius: 16,
+                child: Text(
+                  '#${issue.number}',
+                  style: const TextStyle(
+                      color: AppColors.torchAmber,
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold),
+                ),
+              ),
+              title: Text(
+                issue.title,
+                style: const TextStyle(
+                    color: AppColors.textLight, fontSize: 13),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              subtitle: issue.labelNames.isNotEmpty
+                  ? Text(
+                      issue.labelNames.join(' · '),
+                      style: TextStyle(
+                          color: AppColors.textLight.withValues(alpha: 0.45),
+                          fontSize: 11),
+                    )
+                  : null,
+              trailing: const Icon(Icons.chevron_right,
+                  color: AppColors.stoneMid, size: 18),
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              onTap: () => _openDetail(issue),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Issue detail bottom sheet
+// ---------------------------------------------------------------------------
+
+class _IssueDetailSheet extends StatefulWidget {
+  final IssueItem issue;
+  final String? userId;
+
+  const _IssueDetailSheet({required this.issue, this.userId});
+
+  @override
+  State<_IssueDetailSheet> createState() => _IssueDetailSheetState();
+}
+
+class _IssueDetailSheetState extends State<_IssueDetailSheet> {
+  late Future<List<IssueComment>> _commentsFuture;
+  bool _showCommentBox = false;
+  final _commentCtrl = TextEditingController();
+  bool _submitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _commentsFuture =
+        GithubIssueService.fetchIssueComments(widget.issue.number);
+  }
+
+  @override
+  void dispose() {
+    _commentCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submitComment() async {
+    if (_commentCtrl.text.trim().isEmpty) return;
+    setState(() => _submitting = true);
+    final ok = await GithubIssueService.addComment(
+      issueNumber: widget.issue.number,
+      body: _commentCtrl.text.trim(),
+      userId: widget.userId,
+    );
+    if (!mounted) return;
+    setState(() => _submitting = false);
+    if (ok) {
+      _commentCtrl.clear();
+      setState(() {
+        _showCommentBox = false;
+        _commentsFuture =
+            GithubIssueService.fetchIssueComments(widget.issue.number);
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Comment added — thank you!')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content:
+                Text('Could not submit — check your connection and try again.')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.85,
+      minChildSize: 0.4,
+      maxChildSize: 0.95,
+      builder: (ctx, scrollCtrl) => Column(
+        children: [
+          // Handle
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 10),
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppColors.stoneMid,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          // Header
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CircleAvatar(
+                  backgroundColor: AppColors.stone,
+                  radius: 14,
+                  child: Text(
+                    '#${widget.issue.number}',
+                    style: const TextStyle(
+                        color: AppColors.torchAmber,
+                        fontSize: 9,
+                        fontWeight: FontWeight.bold),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    widget.issue.title,
+                    style: tt.titleSmall?.copyWith(color: AppColors.parchment),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (widget.issue.labelNames.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+              child: Wrap(
+                spacing: 6,
+                children: widget.issue.labelNames
+                    .map((l) => Chip(
+                          label: Text(l,
+                              style: const TextStyle(
+                                  fontSize: 10, color: AppColors.textLight)),
+                          backgroundColor: AppColors.stone,
+                          padding: EdgeInsets.zero,
+                          materialTapTargetSize:
+                              MaterialTapTargetSize.shrinkWrap,
+                          visualDensity: VisualDensity.compact,
+                        ))
+                    .toList(),
+              ),
+            ),
+          const Divider(color: AppColors.stoneMid, height: 1),
+          // Scrollable body
+          Expanded(
+            child: ListView(
+              controller: scrollCtrl,
+              padding: const EdgeInsets.all(20),
+              children: [
+                if (widget.issue.body.isNotEmpty) ...[
+                  Text(
+                    widget.issue.body,
+                    style: tt.bodyMedium?.copyWith(
+                        color: AppColors.textLight.withValues(alpha: 0.85),
+                        height: 1.5),
+                  ),
+                  const SizedBox(height: 20),
+                  const Divider(color: AppColors.stoneMid),
+                  const SizedBox(height: 12),
+                ],
+                Text(
+                  'Comments',
+                  style: tt.labelMedium?.copyWith(color: AppColors.parchment),
+                ),
+                const SizedBox(height: 12),
+                FutureBuilder<List<IssueComment>>(
+                  future: _commentsFuture,
+                  builder: (context, snap) {
+                    if (snap.connectionState != ConnectionState.done) {
+                      return const Padding(
+                        padding: EdgeInsets.all(16),
+                        child: Center(child: CircularProgressIndicator()),
+                      );
+                    }
+                    final comments = snap.data ?? [];
+                    if (comments.isEmpty) {
+                      return Text(
+                        'No comments yet.',
+                        style: tt.bodySmall?.copyWith(
+                            color:
+                                AppColors.textLight.withValues(alpha: 0.4)),
+                      );
+                    }
+                    return Column(
+                      children: comments
+                          .map((c) => _CommentCard(comment: c))
+                          .toList(),
+                    );
+                  },
+                ),
+                const SizedBox(height: 16),
+                if (_showCommentBox) ...[
+                  TextField(
+                    controller: _commentCtrl,
+                    minLines: 3,
+                    maxLines: null,
+                    autofocus: true,
+                    style: const TextStyle(color: AppColors.textLight),
+                    decoration: InputDecoration(
+                      hintText:
+                          'Add any additional context, updates, or follow-up…',
+                      hintStyle: TextStyle(
+                          color: AppColors.textLight.withValues(alpha: 0.4),
+                          fontSize: 13),
+                      filled: true,
+                      fillColor: AppColors.stone,
+                      border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(6),
+                          borderSide:
+                              const BorderSide(color: AppColors.stoneMid)),
+                      enabledBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(6),
+                          borderSide: BorderSide(
+                              color: AppColors.stoneMid.withValues(alpha: 0.6))),
+                      focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(6),
+                          borderSide: const BorderSide(
+                              color: AppColors.torchAmber, width: 1.5)),
+                      contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 10),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: () =>
+                              setState(() => _showCommentBox = false),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: AppColors.textLight,
+                            side: const BorderSide(color: AppColors.stoneMid),
+                          ),
+                          child: const Text('Cancel'),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: ElevatedButton.icon(
+                          onPressed: _submitting ? null : _submitComment,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: AppColors.torchAmber,
+                            foregroundColor: AppColors.textDark,
+                          ),
+                          icon: _submitting
+                              ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      color: AppColors.textDark))
+                              : const Icon(Icons.comment_outlined, size: 16),
+                          label: Text(_submitting ? 'Submitting…' : 'Submit',
+                              style: const TextStyle(
+                                  fontWeight: FontWeight.bold)),
+                        ),
+                      ),
+                    ],
+                  ),
+                ] else
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      onPressed: () => setState(() => _showCommentBox = true),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.torchAmber,
+                        side: const BorderSide(color: AppColors.torchAmber),
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                      ),
+                      icon: const Icon(Icons.add_comment_outlined, size: 16),
+                      label: const Text('Add Comment'),
+                    ),
+                  ),
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Comment card
+// ---------------------------------------------------------------------------
+
+class _CommentCard extends StatelessWidget {
+  final IssueComment comment;
+  const _CommentCard({required this.comment});
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.stone,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.stoneMid.withValues(alpha: 0.4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                comment.authorLogin,
+                style: tt.labelSmall?.copyWith(
+                    color: AppColors.torchAmber,
+                    fontWeight: FontWeight.bold),
+              ),
+              const Spacer(),
+              Text(
+                _formatDate(comment.createdAt),
+                style: tt.labelSmall?.copyWith(
+                    color: AppColors.textLight.withValues(alpha: 0.4)),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            comment.body,
+            style: tt.bodySmall?.copyWith(
+                color: AppColors.textLight.withValues(alpha: 0.8),
+                height: 1.4),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inMinutes < 1) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    if (diff.inDays < 30) return '${diff.inDays}d ago';
+    return '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
   }
 }
 

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -4,7 +4,6 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../../../../core/theme/app_theme.dart';
-import '../../../feedback/data/github_issue_service.dart';
 import '../../data/user_profile_service.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -17,12 +16,10 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   String? _userId;
   String? _appVersion;
-  late Future<List<IssueItem>> _issuesFuture;
 
   @override
   void initState() {
     super.initState();
-    _issuesFuture = GithubIssueService.fetchOpenIssues();
     _load();
   }
 
@@ -43,20 +40,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
     Clipboard.setData(ClipboardData(text: _userId!));
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('User ID copied to clipboard')),
-    );
-  }
-
-  void _showAddComment(IssueItem issue) {
-    showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: AppColors.stoneDark,
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.vertical(top: Radius.circular(16))),
-      builder: (ctx) => _AddCommentSheet(
-        issue: issue,
-        userId: _userId,
-      ),
     );
   }
 
@@ -132,80 +115,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: const Text('Give Feedback',
                 style: TextStyle(color: AppColors.textLight)),
             subtitle: Text(
-              'Report a bug, request a feature, or suggest content',
+              'Report a bug, request a feature, suggest content, or view open issues',
               style: tt.bodySmall?.copyWith(
                   color: AppColors.textLight.withValues(alpha: 0.5)),
             ),
             trailing: const Icon(Icons.chevron_right,
                 color: AppColors.stoneMid),
             onTap: () => context.push('/feedback'),
-          ),
-
-          // ── Open Issues ──────────────────────────────────────────────────
-          const _SectionHeader('Open Issues'),
-          FutureBuilder<List<IssueItem>>(
-            future: _issuesFuture,
-            builder: (context, snap) {
-              if (snap.connectionState != ConnectionState.done) {
-                return const Padding(
-                  padding: EdgeInsets.all(24),
-                  child: Center(child: CircularProgressIndicator()),
-                );
-              }
-              final issues = snap.data ?? [];
-              if (issues.isEmpty) {
-                return Padding(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 16, vertical: 12),
-                  child: Text(
-                    'No open issues — or unable to reach GitHub.',
-                    style: tt.bodySmall?.copyWith(
-                        color: AppColors.textLight.withValues(alpha: 0.4)),
-                  ),
-                );
-              }
-              return Column(
-                children: issues.map((issue) {
-                  return ListTile(
-                    leading: CircleAvatar(
-                      backgroundColor: AppColors.stone,
-                      radius: 16,
-                      child: Text(
-                        '#${issue.number}',
-                        style: const TextStyle(
-                            color: AppColors.torchAmber,
-                            fontSize: 10,
-                            fontWeight: FontWeight.bold),
-                      ),
-                    ),
-                    title: Text(
-                      issue.title,
-                      style: const TextStyle(
-                          color: AppColors.textLight, fontSize: 13),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    subtitle: issue.labelNames.isNotEmpty
-                        ? Text(
-                            issue.labelNames.join(' · '),
-                            style: TextStyle(
-                                color: AppColors.textLight.withValues(alpha: 0.45),
-                                fontSize: 11),
-                          )
-                        : null,
-                    trailing: TextButton(
-                      onPressed: () => _showAddComment(issue),
-                      style: TextButton.styleFrom(
-                          foregroundColor: AppColors.torchAmber),
-                      child: const Text('Comment',
-                          style: TextStyle(fontSize: 12)),
-                    ),
-                    contentPadding:
-                        const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
-                  );
-                }).toList(),
-              );
-            },
           ),
 
           // ── App ──────────────────────────────────────────────────────────
@@ -246,137 +162,6 @@ class _SectionHeader extends StatelessWidget {
               color: AppColors.torchAmber.withValues(alpha: 0.7),
               letterSpacing: 1.2,
             ),
-      ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Add comment bottom sheet
-// ---------------------------------------------------------------------------
-
-class _AddCommentSheet extends StatefulWidget {
-  final IssueItem issue;
-  final String? userId;
-
-  const _AddCommentSheet({required this.issue, this.userId});
-
-  @override
-  State<_AddCommentSheet> createState() => _AddCommentSheetState();
-}
-
-class _AddCommentSheetState extends State<_AddCommentSheet> {
-  final _ctrl = TextEditingController();
-  bool _submitting = false;
-
-  @override
-  void dispose() {
-    _ctrl.dispose();
-    super.dispose();
-  }
-
-  Future<void> _submit() async {
-    if (_ctrl.text.trim().isEmpty) return;
-    setState(() => _submitting = true);
-    final ok = await GithubIssueService.addComment(
-      issueNumber: widget.issue.number,
-      body: _ctrl.text.trim(),
-      userId: widget.userId,
-    );
-    if (!mounted) return;
-    setState(() => _submitting = false);
-    if (ok) {
-      Navigator.of(context).pop();
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Comment added — thank you!')),
-      );
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-            content:
-                Text('Could not submit — check your connection and try again.')),
-      );
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final tt = Theme.of(context).textTheme;
-    return Padding(
-      padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
-        left: 20,
-        right: 20,
-        top: 20,
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Add comment to #${widget.issue.number}',
-            style: tt.titleSmall?.copyWith(color: AppColors.parchment),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            widget.issue.title,
-            style: tt.bodySmall?.copyWith(
-                color: AppColors.textLight.withValues(alpha: 0.55)),
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-          ),
-          const SizedBox(height: 16),
-          TextField(
-            controller: _ctrl,
-            minLines: 3,
-            maxLines: null,
-            autofocus: true,
-            style: const TextStyle(color: AppColors.textLight),
-            decoration: InputDecoration(
-              hintText: 'Add any additional context, updates, or follow-up…',
-              hintStyle: TextStyle(
-                  color: AppColors.textLight.withValues(alpha: 0.4),
-                  fontSize: 13),
-              filled: true,
-              fillColor: AppColors.stone,
-              border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(6),
-                  borderSide: const BorderSide(color: AppColors.stoneMid)),
-              enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(6),
-                  borderSide: BorderSide(
-                      color: AppColors.stoneMid.withValues(alpha: 0.6))),
-              focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(6),
-                  borderSide: const BorderSide(
-                      color: AppColors.torchAmber, width: 1.5)),
-              contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 12, vertical: 10),
-            ),
-          ),
-          const SizedBox(height: 16),
-          SizedBox(
-            width: double.infinity,
-            child: ElevatedButton.icon(
-              onPressed: _submitting ? null : _submit,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.torchAmber,
-                foregroundColor: AppColors.textDark,
-                padding: const EdgeInsets.symmetric(vertical: 14),
-              ),
-              icon: _submitting
-                  ? const SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(
-                          strokeWidth: 2, color: AppColors.textDark))
-                  : const Icon(Icons.comment_outlined),
-              label: Text(_submitting ? 'Submitting…' : 'Submit Comment',
-                  style: const TextStyle(fontWeight: FontWeight.bold)),
-            ),
-          ),
-          const SizedBox(height: 20),
-        ],
       ),
     );
   }

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 - Issue descriptions and comments now display when tapping an issue — body and comment thread were missing due to unparsed API fields and no detail view (#77)
+- "Bug Report" chip removed from the General feedback tab — it was a duplicate of the dedicated Bug Report tab (#75)
 
 ### Content
 - (none)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,10 +3,10 @@
 ## Unreleased
 
 ### Features
-- (none)
+- Issues tab in Feedback — open alpha-feedback issues are now shown in a dedicated "Issues" tab on the Feedback screen instead of the Settings page (#77)
 
 ### Fixes
-- (none)
+- Issue descriptions and comments now display when tapping an issue — body and comment thread were missing due to unparsed API fields and no detail view (#77)
 
 ### Content
 - (none)

--- a/test/features/feedback/issue_item_body_test.dart
+++ b/test/features/feedback/issue_item_body_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mind_mazeish/features/feedback/data/github_issue_service.dart';
+
+// Regression test for sai-pher/Mind-mazeish#77
+//
+// Root cause: IssueItem.fromJson did not parse the `body` field from the
+// GitHub API response, so descriptions were never available to the UI.
+// IssueComment and fetchIssueComments() did not exist at all.
+//
+// Fix: `body` added to IssueItem; IssueComment model and
+// fetchIssueComments() added to GithubIssueService.
+
+void main() {
+  group('IssueItem.fromJson', () {
+    test('parses body field when present', () {
+      final json = {
+        'number': 42,
+        'title': 'Test issue',
+        'body': 'This is the issue description.',
+        'labels': <dynamic>[],
+        'created_at': '2026-04-16T10:00:00Z',
+      };
+
+      final item = IssueItem.fromJson(json);
+
+      expect(item.body, equals('This is the issue description.'));
+    });
+
+    test('defaults body to empty string when null', () {
+      final json = {
+        'number': 43,
+        'title': 'No body issue',
+        'body': null,
+        'labels': <dynamic>[],
+        'created_at': '2026-04-16T10:00:00Z',
+      };
+
+      final item = IssueItem.fromJson(json);
+
+      expect(item.body, equals(''));
+    });
+
+    test('parses number, title, labels and createdAt unchanged', () {
+      final json = {
+        'number': 77,
+        'title': '[Bug Report] Issue descriptions not viewable',
+        'body': 'Some body text.',
+        'labels': [
+          {'name': 'bug'},
+          {'name': 'alpha-feedback'},
+        ],
+        'created_at': '2026-04-16T15:43:44Z',
+      };
+
+      final item = IssueItem.fromJson(json);
+
+      expect(item.number, equals(77));
+      expect(item.title, equals('[Bug Report] Issue descriptions not viewable'));
+      expect(item.labelNames, equals(['bug', 'alpha-feedback']));
+      expect(item.createdAt, equals(DateTime.parse('2026-04-16T15:43:44Z')));
+    });
+  });
+
+  group('IssueComment.fromJson', () {
+    test('parses all fields correctly', () {
+      final json = {
+        'id': 12345,
+        'body': 'This is a comment.',
+        'user': {'login': 'sai-pher'},
+        'created_at': '2026-04-16T18:20:03Z',
+      };
+
+      final comment = IssueComment.fromJson(json);
+
+      expect(comment.id, equals(12345));
+      expect(comment.body, equals('This is a comment.'));
+      expect(comment.authorLogin, equals('sai-pher'));
+      expect(comment.createdAt, equals(DateTime.parse('2026-04-16T18:20:03Z')));
+    });
+
+    test('defaults body to empty string when null', () {
+      final json = {
+        'id': 99,
+        'body': null,
+        'user': {'login': 'ghost'},
+        'created_at': '2026-04-16T12:00:00Z',
+      };
+
+      final comment = IssueComment.fromJson(json);
+
+      expect(comment.body, equals(''));
+    });
+  });
+}

--- a/test/features/feedback/issue_item_body_test.dart
+++ b/test/features/feedback/issue_item_body_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:mind_mazeish/features/feedback/data/github_issue_service.dart';
+import 'package:mind_maze/features/feedback/data/github_issue_service.dart';
 
 // Regression test for sai-pher/Mind-mazeish#77
 //


### PR DESCRIPTION
Closes #77
Closes #75

## Summary
- `IssueItem` now includes the `body` field parsed from the GitHub API list response — previously silently discarded
- New `IssueComment` model and `GithubIssueService.fetchIssueComments()` fetch the comment thread for a single issue
- New `_IssueDetailSheet` bottom sheet renders the full description and comments, with an inline add-comment form; each issue row now has an `onTap` handler
- Issues list moved from `SettingsScreen` to a new **Issues** tab in `FeedbackScreen` — per owner's follow-up comment on #77
- "Bug Report" chip removed from the General tab's category selector — redundant since the dedicated Bug Report tab was added (#75)

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes — regression tests in `test/features/feedback/issue_item_body_test.dart`
- [ ] Manual: Feedback → Issues tab → tap any issue → bottom sheet shows description + comments
- [ ] Manual: tap "Add Comment" in the sheet → submit → comment thread refreshes
- [ ] Manual: Feedback → General tab → confirm "Bug Report" chip is no longer present
- [ ] Manual: Settings → confirm "Open Issues" section is gone