### PR TITLE
feat: user profile page, game stats & adaptive icon fix (#66, #78)

### DIFF
--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_launcher"
+    android:inset="16%" />

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#1A1208</color>
+</resources>

--- a/lib/features/feedback/data/github_issue_service.dart
+++ b/lib/features/feedback/data/github_issue_service.dart
@@ -86,6 +86,7 @@ class GithubIssueService {
     required String body,
     String? appVersion,
     String? userId,
+    String? attribution,
   }) async {
     final issueBody = '''
 ${body.trim()}
@@ -93,7 +94,7 @@ ${body.trim()}
 ---
 **Category:** ${category.emoji} ${category.label}
 **App version:** ${appVersion ?? 'unknown'}
-${userId != null ? '**User ID:** `$userId`\n' : ''}**Source:** In-app feedback
+${attribution != null ? '**Submitted by:** $attribution\n' : userId != null ? '**User ID:** `$userId`\n' : ''}**Source:** In-app feedback
 ''';
 
     return _createIssue(
@@ -145,6 +146,7 @@ ${supportingDetails != null && supportingDetails.trim().isNotEmpty ? '**Supporti
     String? topicId,
     String? appVersion,
     String? userId,
+    String? attribution,
   }) async {
     final issueBody = '''
 ${body.trim()}
@@ -152,7 +154,7 @@ ${body.trim()}
 ---
 **Request type:** ${type.label}
 ${topicId != null ? '**Topic ID:** `$topicId`\n' : ''}**App version:** ${appVersion ?? 'unknown'}
-${userId != null ? '**User ID:** `$userId`\n' : ''}**Source:** In-app content request
+${attribution != null ? '**Submitted by:** $attribution\n' : userId != null ? '**User ID:** `$userId`\n' : ''}**Source:** In-app content request
 ''';
 
     return _createIssue(

--- a/lib/features/feedback/presentation/screens/feedback_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_screen.dart
@@ -6,6 +6,7 @@ import '../../../../core/theme/app_theme.dart';
 import '../../../gameplay/data/topic_registry.dart';
 import '../../data/feedback_draft_repository.dart';
 import '../../../settings/data/user_profile_service.dart';
+import '../../../settings/domain/models/user_profile.dart';
 import '../../data/github_issue_service.dart';
 
 // Tab indices
@@ -24,7 +25,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _tabs;
   String? _appVersion;
-  String? _userId;
+  UserProfile? _profile;
 
   /// Incremented whenever a draft is saved or deleted, triggering the
   /// Pending tab to reload.
@@ -40,8 +41,8 @@ class _FeedbackScreenState extends State<FeedbackScreen>
     PackageInfo.fromPlatform().then((i) {
       if (mounted) setState(() => _appVersion = '${i.version}+${i.buildNumber}');
     });
-    UserProfileService.getUserId().then((id) {
-      if (mounted) setState(() => _userId = id);
+    UserProfileService.getProfile().then((p) {
+      if (mounted) setState(() => _profile = p);
     });
   }
 
@@ -88,7 +89,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
         children: [
           _GeneralFeedbackTab(
             appVersion: _appVersion,
-            userId: _userId,
+            profile: _profile,
             loadedDraft: _loadedDraft?.type == 'general' ? _loadedDraft : null,
             onDraftLoaded: _onDraftLoaded,
             onDraftSaved: _onDraftSaved,
@@ -96,7 +97,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
           _BugReportTab(appVersion: _appVersion),
           _ContentRequestTab(
             appVersion: _appVersion,
-            userId: _userId,
+            profile: _profile,
             loadedDraft: _loadedDraft?.type == 'content' ? _loadedDraft : null,
             onDraftLoaded: _onDraftLoaded,
             onDraftSaved: _onDraftSaved,
@@ -106,7 +107,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
             onLoadDraft: _loadDraft,
             onDraftDeleted: _onDraftSaved,
           ),
-          _IssuesTab(userId: _userId),
+          _IssuesTab(userId: _profile?.userId),
         ],
       ),
     );
@@ -119,14 +120,14 @@ class _FeedbackScreenState extends State<FeedbackScreen>
 
 class _GeneralFeedbackTab extends StatefulWidget {
   final String? appVersion;
-  final String? userId;
+  final UserProfile? profile;
   final FeedbackDraft? loadedDraft;
   final VoidCallback onDraftLoaded;
   final VoidCallback onDraftSaved;
 
   const _GeneralFeedbackTab({
     this.appVersion,
-    this.userId,
+    this.profile,
     this.loadedDraft,
     required this.onDraftLoaded,
     required this.onDraftSaved,
@@ -179,7 +180,8 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
       title: _titleCtrl.text.trim(),
       body: _bodyCtrl.text.trim(),
       appVersion: widget.appVersion,
-      userId: widget.userId,
+      userId: widget.profile?.userId,
+      attribution: widget.profile?.attribution,
     );
     if (!mounted) return;
     setState(() => _submitting = false);
@@ -472,14 +474,14 @@ class _BugReportTabState extends State<_BugReportTab> {
 
 class _ContentRequestTab extends StatefulWidget {
   final String? appVersion;
-  final String? userId;
+  final UserProfile? profile;
   final FeedbackDraft? loadedDraft;
   final VoidCallback onDraftLoaded;
   final VoidCallback onDraftSaved;
 
   const _ContentRequestTab({
     this.appVersion,
-    this.userId,
+    this.profile,
     this.loadedDraft,
     required this.onDraftLoaded,
     required this.onDraftSaved,
@@ -541,7 +543,8 @@ class _ContentRequestTabState extends State<_ContentRequestTab> {
           : _bodyCtrl.text.trim(),
       topicId: _selectedTopicId,
       appVersion: widget.appVersion,
-      userId: widget.userId,
+      userId: widget.profile?.userId,
+      attribution: widget.profile?.attribution,
     );
     if (!mounted) return;
     setState(() => _submitting = false);

--- a/lib/features/results/presentation/screens/results_screen.dart
+++ b/lib/features/results/presentation/screens/results_screen.dart
@@ -6,12 +6,50 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../gameplay/domain/models/game_state.dart';
 import '../../../gameplay/presentation/providers/game_state_provider.dart';
+import '../../../settings/data/game_stats_repository.dart';
 
-class ResultsScreen extends ConsumerWidget {
+class ResultsScreen extends ConsumerStatefulWidget {
   const ResultsScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ResultsScreen> createState() => _ResultsScreenState();
+}
+
+class _ResultsScreenState extends ConsumerState<ResultsScreen> {
+  bool _statsRecorded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _recordStats());
+  }
+
+  Future<void> _recordStats() async {
+    if (_statsRecorded) return;
+    final gs = ref.read(gameStateProvider);
+    if (gs == null) return;
+    final finished =
+        gs.status == GameStatus.gameOver || gs.status == GameStatus.complete;
+    if (!finished) return;
+    _statsRecorded = true;
+    await GameStatsRepository.recordGame(
+      score: gs.score,
+      correct: gs.correctCount,
+      answered: gs.questionsAnswered,
+      articlesFound: gs.newArticleUrls.length,
+      won: gs.status == GameStatus.complete,
+    );
+  }
+
+  int _starCount(int score, int answered, int total) {
+    if (answered == total && score >= total * 8) return 3;
+    if (answered >= total * 0.6 && score >= total * 4) return 2;
+    if (score >= 10) return 1;
+    return 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final gs = ref.watch(gameStateProvider);
     final textTheme = Theme.of(context).textTheme;
 
@@ -172,13 +210,6 @@ class ResultsScreen extends ConsumerWidget {
         ],
       ),
     );
-  }
-
-  int _starCount(int score, int answered, int total) {
-    if (answered == total && score >= total * 8) return 3;
-    if (answered >= total * 0.6 && score >= total * 4) return 2;
-    if (score >= 10) return 1;
-    return 0;
   }
 }
 

--- a/lib/features/settings/data/game_stats_repository.dart
+++ b/lib/features/settings/data/game_stats_repository.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../domain/models/game_stats.dart';
+
+class GameStatsRepository {
+  static const _key = 'game_stats_v1';
+
+  static Future<GameStats> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return const GameStats();
+    try {
+      return GameStats.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+    } catch (_) {
+      return const GameStats();
+    }
+  }
+
+  static Future<void> save(GameStats stats) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, jsonEncode(stats.toJson()));
+  }
+
+  static Future<GameStats> recordGame({
+    required int score,
+    required int correct,
+    required int answered,
+    required int articlesFound,
+    required bool won,
+  }) async {
+    final current = await load();
+    final updated = current.recordGame(
+      score: score,
+      correct: correct,
+      answered: answered,
+      articlesFound: articlesFound,
+      won: won,
+    );
+    await save(updated);
+    return updated;
+  }
+}

--- a/lib/features/settings/data/user_profile_service.dart
+++ b/lib/features/settings/data/user_profile_service.dart
@@ -1,24 +1,50 @@
 import 'dart:math';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../domain/models/user_profile.dart';
 
-/// Manages a stable, anonymous local user identifier.
-///
-/// The ID is generated once on first use (`usr_` + 12 random hex characters)
-/// and persisted in shared_preferences. It is attached to all feedback
-/// submissions so reports from the same tester can be grouped without
-/// requiring an account.
 class UserProfileService {
-  static const _key = 'user_profile_id';
+  static const _keyId          = 'user_profile_id';
+  static const _keyDisplayName = 'user_profile_display_name';
+  static const _keyEmoji       = 'user_profile_emoji';
+  static const _keyGithubUrl   = 'user_profile_github_url';
 
-  /// Returns the stored user ID, generating one if none exists yet.
+  /// Returns the stable anonymous user ID, generating one if needed.
   static Future<String> getUserId() async {
     final prefs = await SharedPreferences.getInstance();
-    var id = prefs.getString(_key);
+    var id = prefs.getString(_keyId);
     if (id == null || id.isEmpty) {
       id = _generateId();
-      await prefs.setString(_key, id);
+      await prefs.setString(_keyId, id);
     }
     return id;
+  }
+
+  /// Returns the full profile including the anonymous ID.
+  static Future<UserProfile> getProfile() async {
+    final prefs = await SharedPreferences.getInstance();
+    var id = prefs.getString(_keyId);
+    if (id == null || id.isEmpty) {
+      id = _generateId();
+      await prefs.setString(_keyId, id);
+    }
+    return UserProfile(
+      userId: id,
+      displayName: prefs.getString(_keyDisplayName) ?? '',
+      emoji: prefs.getString(_keyEmoji) ?? '',
+      githubUrl: prefs.getString(_keyGithubUrl) ?? '',
+    );
+  }
+
+  /// Persists mutable profile fields. The userId is never changed.
+  static Future<void> saveProfile({
+    required String displayName,
+    required String emoji,
+    required String githubUrl,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_keyDisplayName, displayName.trim());
+    await prefs.setString(_keyEmoji, emoji.trim());
+    await prefs.setString(_keyGithubUrl, githubUrl.trim());
   }
 
   static String _generateId() {

--- a/lib/features/settings/domain/models/game_stats.dart
+++ b/lib/features/settings/domain/models/game_stats.dart
@@ -1,0 +1,63 @@
+class GameStats {
+  final int gamesPlayed;
+  final int totalWins;
+  final int bestScore;
+  final int totalScore;
+  final int totalCorrect;
+  final int totalAnswered;
+  final int totalArticlesFound;
+
+  const GameStats({
+    this.gamesPlayed = 0,
+    this.totalWins = 0,
+    this.bestScore = 0,
+    this.totalScore = 0,
+    this.totalCorrect = 0,
+    this.totalAnswered = 0,
+    this.totalArticlesFound = 0,
+  });
+
+  double get accuracy =>
+      totalAnswered == 0 ? 0 : totalCorrect / totalAnswered;
+
+  double get winRate =>
+      gamesPlayed == 0 ? 0 : totalWins / gamesPlayed;
+
+  GameStats recordGame({
+    required int score,
+    required int correct,
+    required int answered,
+    required int articlesFound,
+    required bool won,
+  }) {
+    return GameStats(
+      gamesPlayed: gamesPlayed + 1,
+      totalWins: won ? totalWins + 1 : totalWins,
+      bestScore: score > bestScore ? score : bestScore,
+      totalScore: totalScore + score,
+      totalCorrect: totalCorrect + correct,
+      totalAnswered: totalAnswered + answered,
+      totalArticlesFound: totalArticlesFound + articlesFound,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'gamesPlayed': gamesPlayed,
+        'totalWins': totalWins,
+        'bestScore': bestScore,
+        'totalScore': totalScore,
+        'totalCorrect': totalCorrect,
+        'totalAnswered': totalAnswered,
+        'totalArticlesFound': totalArticlesFound,
+      };
+
+  factory GameStats.fromJson(Map<String, dynamic> json) => GameStats(
+        gamesPlayed: (json['gamesPlayed'] as int?) ?? 0,
+        totalWins: (json['totalWins'] as int?) ?? 0,
+        bestScore: (json['bestScore'] as int?) ?? 0,
+        totalScore: (json['totalScore'] as int?) ?? 0,
+        totalCorrect: (json['totalCorrect'] as int?) ?? 0,
+        totalAnswered: (json['totalAnswered'] as int?) ?? 0,
+        totalArticlesFound: (json['totalArticlesFound'] as int?) ?? 0,
+      );
+}

--- a/lib/features/settings/domain/models/game_stats.dart
+++ b/lib/features/settings/domain/models/game_stats.dart
@@ -18,10 +18,10 @@ class GameStats {
   });
 
   double get accuracy =>
-      totalAnswered == 0 ? 0 : totalCorrect / totalAnswered;
+      totalAnswered == 0 ? 0.0 : totalCorrect / totalAnswered;
 
   double get winRate =>
-      gamesPlayed == 0 ? 0 : totalWins / gamesPlayed;
+      gamesPlayed == 0 ? 0.0 : totalWins / gamesPlayed;
 
   GameStats recordGame({
     required int score,

--- a/lib/features/settings/domain/models/user_profile.dart
+++ b/lib/features/settings/domain/models/user_profile.dart
@@ -1,0 +1,41 @@
+class UserProfile {
+  final String userId;
+  final String displayName;
+  final String emoji;
+  final String githubUrl;
+
+  const UserProfile({
+    required this.userId,
+    this.displayName = '',
+    this.emoji = '',
+    this.githubUrl = '',
+  });
+
+  bool get hasDisplayName => displayName.isNotEmpty;
+  bool get hasEmoji => emoji.isNotEmpty;
+  bool get hasGithubUrl => githubUrl.isNotEmpty;
+
+  /// Markdown attribution line used in GitHub issue bodies.
+  /// e.g. "🧙 [Ada](https://github.com/ada)" or "🧙 Ada" or just the userId.
+  String get attribution {
+    final emojiPart = hasEmoji ? '$emoji ' : '';
+    if (hasDisplayName && hasGithubUrl) {
+      return '$emojiPart[$displayName]($githubUrl)';
+    }
+    if (hasDisplayName) return '$emojiPart$displayName';
+    return '`$userId`';
+  }
+
+  UserProfile copyWith({
+    String? displayName,
+    String? emoji,
+    String? githubUrl,
+  }) {
+    return UserProfile(
+      userId: userId,
+      displayName: displayName ?? this.displayName,
+      emoji: emoji ?? this.emoji,
+      githubUrl: githubUrl ?? this.githubUrl,
+    );
+  }
+}

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -82,6 +82,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _dirty   = false;
       _saving  = false;
     });
+    if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Profile saved')),
     );

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -47,20 +47,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _load() async {
-    final results = await Future.wait([
-      UserProfileService.getProfile(),
-      GameStatsRepository.load(),
-      PackageInfo.fromPlatform().then((i) => '${i.version}+${i.buildNumber}'),
-    ]);
+    final profileFuture = UserProfileService.getProfile();
+    final statsFuture   = GameStatsRepository.load();
+    final versionFuture = PackageInfo.fromPlatform();
+    final profile  = await profileFuture;
+    final stats    = await statsFuture;
+    final pkgInfo  = await versionFuture;
     if (!mounted) return;
-    final profile = results[0] as UserProfile;
     setState(() {
-      _profile       = profile;
-      _stats         = results[1] as GameStats;
-      _appVersion    = results[2] as String;
+      _profile    = profile;
+      _stats      = stats;
+      _appVersion = '${pkgInfo.version}+${pkgInfo.buildNumber}';
       _displayNameCtrl.text = profile.displayName;
       _githubUrlCtrl.text   = profile.githubUrl;
-      _selectedEmoji = profile.emoji;
+      _selectedEmoji        = profile.emoji;
     });
   }
 

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -4,7 +4,16 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../../../../core/theme/app_theme.dart';
+import '../../data/game_stats_repository.dart';
 import '../../data/user_profile_service.dart';
+import '../../domain/models/game_stats.dart';
+import '../../domain/models/user_profile.dart';
+
+// Common emoji options for the avatar picker.
+const _kEmojiOptions = [
+  '🧙', '🧝', '🧛', '🧟', '🏰', '⚔️', '🛡️', '👑',
+  '🐉', '🦁', '🦊', '🐺', '🦅', '🌙', '⭐', '🔮',
+];
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -14,8 +23,15 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  String? _userId;
+  UserProfile? _profile;
+  GameStats? _stats;
   String? _appVersion;
+
+  final _displayNameCtrl = TextEditingController();
+  final _githubUrlCtrl   = TextEditingController();
+  String _selectedEmoji  = '';
+  bool _dirty            = false;
+  bool _saving           = false;
 
   @override
   void initState() {
@@ -23,21 +39,57 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _load();
   }
 
+  @override
+  void dispose() {
+    _displayNameCtrl.dispose();
+    _githubUrlCtrl.dispose();
+    super.dispose();
+  }
+
   Future<void> _load() async {
     final results = await Future.wait([
-      UserProfileService.getUserId(),
+      UserProfileService.getProfile(),
+      GameStatsRepository.load(),
       PackageInfo.fromPlatform().then((i) => '${i.version}+${i.buildNumber}'),
     ]);
     if (!mounted) return;
+    final profile = results[0] as UserProfile;
     setState(() {
-      _userId     = results[0];
-      _appVersion = results[1];
+      _profile       = profile;
+      _stats         = results[1] as GameStats;
+      _appVersion    = results[2] as String;
+      _displayNameCtrl.text = profile.displayName;
+      _githubUrlCtrl.text   = profile.githubUrl;
+      _selectedEmoji = profile.emoji;
     });
   }
 
+  void _markDirty() {
+    if (!_dirty) setState(() => _dirty = true);
+  }
+
+  Future<void> _saveProfile() async {
+    setState(() => _saving = true);
+    await UserProfileService.saveProfile(
+      displayName: _displayNameCtrl.text,
+      emoji: _selectedEmoji,
+      githubUrl: _githubUrlCtrl.text,
+    );
+    if (!mounted) return;
+    final updated = await UserProfileService.getProfile();
+    setState(() {
+      _profile = updated;
+      _dirty   = false;
+      _saving  = false;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Profile saved')),
+    );
+  }
+
   void _copyUserId() {
-    if (_userId == null) return;
-    Clipboard.setData(ClipboardData(text: _userId!));
+    if (_profile == null) return;
+    Clipboard.setData(ClipboardData(text: _profile!.userId));
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('User ID copied to clipboard')),
     );
@@ -69,16 +121,117 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    // Emoji avatar picker
+                    Text(
+                      'Avatar',
+                      style: tt.labelMedium
+                          ?.copyWith(color: AppColors.parchment),
+                    ),
+                    const SizedBox(height: 8),
+                    _EmojiPicker(
+                      selected: _selectedEmoji,
+                      onSelected: (e) {
+                        setState(() => _selectedEmoji = e);
+                        _markDirty();
+                      },
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Display name
+                    Text(
+                      'Display name',
+                      style: tt.labelMedium
+                          ?.copyWith(color: AppColors.parchment),
+                    ),
+                    const SizedBox(height: 6),
+                    TextField(
+                      controller: _displayNameCtrl,
+                      maxLength: 40,
+                      style: const TextStyle(color: AppColors.textLight),
+                      decoration: InputDecoration(
+                        hintText: 'How should we call you?',
+                        hintStyle: TextStyle(
+                            color: AppColors.textLight.withValues(alpha: 0.4)),
+                        filled: true,
+                        fillColor: AppColors.stoneDark,
+                        counterStyle: TextStyle(
+                            color: AppColors.textLight.withValues(alpha: 0.4)),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(6),
+                          borderSide: BorderSide.none,
+                        ),
+                        contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 10),
+                      ),
+                      onChanged: (_) => _markDirty(),
+                    ),
+                    const SizedBox(height: 12),
+
+                    // GitHub URL
+                    Text(
+                      'GitHub profile (optional)',
+                      style: tt.labelMedium
+                          ?.copyWith(color: AppColors.parchment),
+                    ),
+                    const SizedBox(height: 6),
+                    TextField(
+                      controller: _githubUrlCtrl,
+                      keyboardType: TextInputType.url,
+                      style: const TextStyle(color: AppColors.textLight),
+                      decoration: InputDecoration(
+                        hintText: 'https://github.com/username',
+                        hintStyle: TextStyle(
+                            color: AppColors.textLight.withValues(alpha: 0.4)),
+                        filled: true,
+                        fillColor: AppColors.stoneDark,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(6),
+                          borderSide: BorderSide.none,
+                        ),
+                        contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 10),
+                      ),
+                      onChanged: (_) => _markDirty(),
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Save button
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton(
+                        onPressed: _dirty && !_saving ? _saveProfile : null,
+                        style: FilledButton.styleFrom(
+                          backgroundColor: AppColors.torchAmber,
+                          foregroundColor: AppColors.textDark,
+                          disabledBackgroundColor:
+                              AppColors.stone.withValues(alpha: 0.5),
+                        ),
+                        child: _saving
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: AppColors.textDark),
+                              )
+                            : const Text('Save profile'),
+                      ),
+                    ),
+
+                    const Divider(height: 24, color: AppColors.stoneDark),
+
+                    // Anonymous tester ID (read-only)
                     Text(
                       'Anonymous tester ID',
-                      style: tt.labelMedium?.copyWith(color: AppColors.parchment),
+                      style: tt.labelMedium
+                          ?.copyWith(color: AppColors.parchment),
                     ),
                     const SizedBox(height: 6),
                     Row(
                       children: [
                         Expanded(
                           child: Text(
-                            _userId ?? '…',
+                            _profile?.userId ?? '…',
                             style: tt.bodyMedium?.copyWith(
                               color: AppColors.torchAmber,
                               fontFamily: 'monospace',
@@ -107,6 +260,37 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
           ),
 
+          // ── Game Stats ───────────────────────────────────────────────────
+          const _SectionHeader('Game Stats'),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Card(
+              color: AppColors.stone,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8)),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: _stats == null
+                    ? const Center(
+                        child: CircularProgressIndicator(
+                            color: AppColors.torchAmber))
+                    : _stats!.gamesPlayed == 0
+                        ? Center(
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 8),
+                              child: Text(
+                                'No games played yet',
+                                style: tt.bodyMedium?.copyWith(
+                                    color: AppColors.textLight
+                                        .withValues(alpha: 0.5)),
+                              ),
+                            ),
+                          )
+                        : _StatsGrid(stats: _stats!),
+              ),
+            ),
+          ),
+
           // ── Feedback ─────────────────────────────────────────────────────
           const _SectionHeader('Feedback'),
           ListTile(
@@ -119,8 +303,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               style: tt.bodySmall?.copyWith(
                   color: AppColors.textLight.withValues(alpha: 0.5)),
             ),
-            trailing: const Icon(Icons.chevron_right,
-                color: AppColors.stoneMid),
+            trailing: const Icon(Icons.chevron_right, color: AppColors.stoneMid),
             onTap: () => context.push('/feedback'),
           ),
 
@@ -138,6 +321,116 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
 
           const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Emoji avatar picker
+// ---------------------------------------------------------------------------
+
+class _EmojiPicker extends StatelessWidget {
+  final String selected;
+  final ValueChanged<String> onSelected;
+
+  const _EmojiPicker({required this.selected, required this.onSelected});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: _kEmojiOptions.map((e) {
+        final isSelected = e == selected;
+        return GestureDetector(
+          onTap: () => onSelected(isSelected ? '' : e),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: isSelected
+                  ? AppColors.torchAmber.withValues(alpha: 0.25)
+                  : AppColors.stoneDark,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: isSelected ? AppColors.torchAmber : Colors.transparent,
+                width: 2,
+              ),
+            ),
+            child: Center(
+              child: Text(e, style: const TextStyle(fontSize: 20)),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Game stats grid
+// ---------------------------------------------------------------------------
+
+class _StatsGrid extends StatelessWidget {
+  final GameStats stats;
+  const _StatsGrid({required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    final accuracyPct = (stats.accuracy * 100).toStringAsFixed(0);
+    final winPct      = (stats.winRate * 100).toStringAsFixed(0);
+
+    return Column(
+      children: [
+        Row(
+          children: [
+            _StatCell(label: 'Games Played', value: '${stats.gamesPlayed}'),
+            _StatCell(label: 'Best Score',   value: '${stats.bestScore}'),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            _StatCell(label: 'Win Rate',  value: '$winPct%'),
+            _StatCell(label: 'Accuracy',  value: '$accuracyPct%'),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            _StatCell(label: 'Articles Found', value: '${stats.totalArticlesFound}'),
+            _StatCell(label: 'Total Score',    value: '${stats.totalScore}'),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _StatCell extends StatelessWidget {
+  final String label;
+  final String value;
+  const _StatCell({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            value,
+            style: tt.headlineSmall?.copyWith(color: AppColors.torchGold),
+          ),
+          Text(
+            label,
+            style: tt.labelSmall?.copyWith(
+                color: AppColors.textLight.withValues(alpha: 0.6)),
+          ),
         ],
       ),
     );

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,10 +3,11 @@
 ## Unreleased
 
 ### Features
-- (none)
+- User profile page — set a display name, pick an emoji avatar, and optionally link a GitHub profile; display name and emoji now sign all feedback submissions (#78)
+- Game stats in Settings — cumulative stats (games played, best score, win rate, accuracy, total articles found) are recorded after each game and shown on the Settings screen (#78)
 
 ### Fixes
-- (none)
+- App icon no longer shows as a small image inside a white circle on Android 8.0+ devices — added adaptive icon configuration (`mipmap-anydpi-v26`) with the castle dark background (#66)
 
 ### Content
 - (none)

--- a/test/features/settings/domain/game_stats_test.dart
+++ b/test/features/settings/domain/game_stats_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mind_maze/features/settings/domain/models/game_stats.dart';
+
+void main() {
+  group('GameStats', () {
+    test('defaults are all zero', () {
+      const s = GameStats();
+      expect(s.gamesPlayed, 0);
+      expect(s.totalWins, 0);
+      expect(s.bestScore, 0);
+      expect(s.totalScore, 0);
+      expect(s.totalCorrect, 0);
+      expect(s.totalAnswered, 0);
+      expect(s.totalArticlesFound, 0);
+    });
+
+    test('accuracy is 0 when no answers', () {
+      expect(const GameStats().accuracy, 0.0);
+    });
+
+    test('winRate is 0 when no games', () {
+      expect(const GameStats().winRate, 0.0);
+    });
+
+    group('recordGame', () {
+      test('increments gamesPlayed', () {
+        final s = const GameStats().recordGame(
+          score: 10, correct: 1, answered: 2, articlesFound: 0, won: false,
+        );
+        expect(s.gamesPlayed, 1);
+      });
+
+      test('updates bestScore only when higher', () {
+        var s = const GameStats().recordGame(
+          score: 50, correct: 5, answered: 5, articlesFound: 0, won: true,
+        );
+        s = s.recordGame(
+          score: 30, correct: 3, answered: 5, articlesFound: 0, won: true,
+        );
+        expect(s.bestScore, 50);
+
+        s = s.recordGame(
+          score: 80, correct: 8, answered: 10, articlesFound: 2, won: true,
+        );
+        expect(s.bestScore, 80);
+      });
+
+      test('totalWins increments only on won=true', () {
+        var s = const GameStats().recordGame(
+          score: 0, correct: 0, answered: 5, articlesFound: 0, won: false,
+        );
+        expect(s.totalWins, 0);
+
+        s = s.recordGame(
+          score: 50, correct: 5, answered: 5, articlesFound: 0, won: true,
+        );
+        expect(s.totalWins, 1);
+      });
+
+      test('accumulates totalScore, totalCorrect, totalAnswered, totalArticlesFound', () {
+        var s = const GameStats().recordGame(
+          score: 40, correct: 4, answered: 5, articlesFound: 2, won: true,
+        );
+        s = s.recordGame(
+          score: 60, correct: 6, answered: 10, articlesFound: 3, won: true,
+        );
+        expect(s.totalScore, 100);
+        expect(s.totalCorrect, 10);
+        expect(s.totalAnswered, 15);
+        expect(s.totalArticlesFound, 5);
+      });
+
+      test('accuracy computes correctly', () {
+        final s = const GameStats().recordGame(
+          score: 80, correct: 8, answered: 10, articlesFound: 0, won: true,
+        );
+        expect(s.accuracy, closeTo(0.8, 0.0001));
+      });
+
+      test('winRate computes correctly', () {
+        var s = const GameStats().recordGame(
+          score: 50, correct: 5, answered: 5, articlesFound: 0, won: true,
+        );
+        s = s.recordGame(
+          score: 0, correct: 0, answered: 5, articlesFound: 0, won: false,
+        );
+        expect(s.winRate, closeTo(0.5, 0.0001));
+      });
+    });
+
+    group('JSON serialisation', () {
+      test('round-trips through toJson/fromJson', () {
+        const original = GameStats(
+          gamesPlayed: 5,
+          totalWins: 3,
+          bestScore: 90,
+          totalScore: 350,
+          totalCorrect: 35,
+          totalAnswered: 50,
+          totalArticlesFound: 12,
+        );
+        final restored = GameStats.fromJson(original.toJson());
+        expect(restored.gamesPlayed, original.gamesPlayed);
+        expect(restored.totalWins, original.totalWins);
+        expect(restored.bestScore, original.bestScore);
+        expect(restored.totalScore, original.totalScore);
+        expect(restored.totalCorrect, original.totalCorrect);
+        expect(restored.totalAnswered, original.totalAnswered);
+        expect(restored.totalArticlesFound, original.totalArticlesFound);
+      });
+
+      test('fromJson handles missing keys gracefully', () {
+        final s = GameStats.fromJson({});
+        expect(s.gamesPlayed, 0);
+        expect(s.bestScore, 0);
+      });
+    });
+  });
+}

--- a/test/features/settings/domain/user_profile_test.dart
+++ b/test/features/settings/domain/user_profile_test.dart
@@ -26,7 +26,7 @@ void main() {
 
     group('attribution', () {
       test('falls back to userId when no display name', () {
-        final p = UserProfile(userId: userId);
+        const p = UserProfile(userId: userId);
         expect(p.attribution, '`$userId`');
       });
 

--- a/test/features/settings/domain/user_profile_test.dart
+++ b/test/features/settings/domain/user_profile_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mind_maze/features/settings/domain/models/user_profile.dart';
+
+void main() {
+  group('UserProfile', () {
+    const userId = 'usr_abc123def456';
+
+    test('hasDisplayName is false when empty', () {
+      expect(const UserProfile(userId: userId).hasDisplayName, isFalse);
+    });
+
+    test('hasDisplayName is true when set', () {
+      expect(
+        const UserProfile(userId: userId, displayName: 'Ada').hasDisplayName,
+        isTrue,
+      );
+    });
+
+    test('hasEmoji is false when empty', () {
+      expect(const UserProfile(userId: userId).hasEmoji, isFalse);
+    });
+
+    test('hasGithubUrl is false when empty', () {
+      expect(const UserProfile(userId: userId).hasGithubUrl, isFalse);
+    });
+
+    group('attribution', () {
+      test('falls back to userId when no display name', () {
+        final p = UserProfile(userId: userId);
+        expect(p.attribution, '`$userId`');
+      });
+
+      test('shows emoji + name when no GitHub URL', () {
+        const p = UserProfile(
+          userId: userId,
+          displayName: 'Ada',
+          emoji: '🧙',
+        );
+        expect(p.attribution, '🧙 Ada');
+      });
+
+      test('shows name only (no emoji prefix) when emoji is empty', () {
+        const p = UserProfile(userId: userId, displayName: 'Ada');
+        expect(p.attribution, 'Ada');
+      });
+
+      test('shows emoji + markdown link when both name and GitHub URL set', () {
+        const p = UserProfile(
+          userId: userId,
+          displayName: 'Ada',
+          emoji: '🧙',
+          githubUrl: 'https://github.com/ada',
+        );
+        expect(p.attribution, '🧙 [Ada](https://github.com/ada)');
+      });
+
+      test('shows plain markdown link (no emoji) when emoji is empty', () {
+        const p = UserProfile(
+          userId: userId,
+          displayName: 'Ada',
+          githubUrl: 'https://github.com/ada',
+        );
+        expect(p.attribution, '[Ada](https://github.com/ada)');
+      });
+    });
+
+    group('copyWith', () {
+      test('preserves userId and updates provided fields', () {
+        const original = UserProfile(
+          userId: userId,
+          displayName: 'Ada',
+          emoji: '🧙',
+          githubUrl: 'https://github.com/ada',
+        );
+        final updated = original.copyWith(displayName: 'Bob');
+        expect(updated.userId, userId);
+        expect(updated.displayName, 'Bob');
+        expect(updated.emoji, '🧙');
+        expect(updated.githubUrl, 'https://github.com/ada');
+      });
+
+      test('does not modify the original', () {
+        const original = UserProfile(userId: userId, displayName: 'Ada');
+        original.copyWith(displayName: 'Bob');
+        expect(original.displayName, 'Ada');
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #66
Closes #78

## Summary

- **#66 — App icon fix**: Added `mipmap-anydpi-v26/ic_launcher.xml` and `ic_launcher_round.xml` adaptive icon specs with a `#1A1208` (castle dark) background. The existing PNG is wrapped in an `<inset>` foreground drawable, so the icon fills its full shape instead of appearing as a small image inside a white circle on Android 8.0+ devices.

- **#78 — User profile page**: Expanded the Settings screen with a full profile editor (display name, emoji avatar picker, optional GitHub profile URL). Display name + emoji now sign all feedback and content-request submissions as a markdown attribution line; if a GitHub URL is provided the name becomes a link.

- **#78 — Game stats**: New `GameStats` model + `GameStatsRepository` (SharedPreferences-backed). The Results screen records stats after each game (score, accuracy, articles found, win/loss). Settings shows cumulative stats: games played, best score, win rate, accuracy %, total articles found.

## Changed files

| File | Change |
|------|--------|
| `android/…/mipmap-anydpi-v26/ic_launcher{,_round}.xml` | New — adaptive icon spec |
| `android/…/drawable/ic_launcher_foreground.xml` | New — inset wrapper for PNG foreground layer |
| `android/…/values/colors.xml` | New — `ic_launcher_background` colour resource |
| `lib/features/settings/domain/models/user_profile.dart` | New — `UserProfile` model with `attribution` helper |
| `lib/features/settings/domain/models/game_stats.dart` | New — `GameStats` model with JSON serialisation |
| `lib/features/settings/data/game_stats_repository.dart` | New — SharedPreferences-backed stats storage |
| `lib/features/settings/data/user_profile_service.dart` | Extended — display name, emoji, GitHub URL persistence |
| `lib/features/settings/presentation/screens/settings_screen.dart` | Expanded — emoji picker, profile form, Game Stats section |
| `lib/features/feedback/data/github_issue_service.dart` | Updated — `attribution` param added to general + content submissions |
| `lib/features/feedback/presentation/screens/feedback_screen.dart` | Updated — loads full `UserProfile`; passes attribution to service |
| `lib/features/results/presentation/screens/results_screen.dart` | Updated — records game stats on first render via `GameStatsRepository` |
| `release_notes.md` | Updated — Unreleased section |

## Test plan

- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes
- [ ] **#66**: Install on Android 8.0+ device — launcher icon fills full shape with dark background, no white circle
- [ ] **#78 profile**: Open Settings → fill in display name, pick emoji, enter GitHub URL → tap Save → close and reopen Settings → values persisted
- [ ] **#78 feedback attribution**: Submit a general feedback item → check GitHub issue body contains `**Submitted by:** 🧙 [Name](url)` line
- [ ] **#78 game stats**: Complete a game → open Settings → Game Stats card shows non-zero values
- [ ] **#78 empty state**: Fresh install → Game Stats card shows "No games played yet"

https://claude.ai/code/session_01Ns1WNVpzM2ZcNjGFnQAP2y