### PR TITLE
feat: endless mode streak counter, life recovery & high score (#57 #74)

### DIFF
--- a/lib/features/gameplay/domain/models/game_state.dart
+++ b/lib/features/gameplay/domain/models/game_state.dart
@@ -3,6 +3,8 @@ import 'quiz_config.dart';
 
 enum GameStatus { idle, loading, playing, answerRevealed, gameOver, complete }
 
+enum StreakReward { lifeRestored, bonusPoints }
+
 class GameState {
   final List<QuizQuestion> questions;
   final int currentQuestionIndex;
@@ -13,6 +15,7 @@ class GameState {
   final Set<String> seenArticleUrls;
   final Set<String> newArticleUrls;
   final List<bool?> answeredCorrectly;
+  final int streak;
 
   const GameState({
     required this.questions,
@@ -24,6 +27,7 @@ class GameState {
     required this.seenArticleUrls,
     required this.newArticleUrls,
     required this.answeredCorrectly,
+    this.streak = 0,
   });
 
   factory GameState.initial({
@@ -40,6 +44,7 @@ class GameState {
       seenArticleUrls: const {},
       newArticleUrls: const {},
       answeredCorrectly: List.filled(questions.length, null),
+      streak: 0,
     );
   }
 
@@ -60,6 +65,7 @@ class GameState {
     Set<String>? seenArticleUrls,
     Set<String>? newArticleUrls,
     List<bool?>? answeredCorrectly,
+    int? streak,
   }) {
     return GameState(
       questions: questions ?? this.questions,
@@ -71,14 +77,38 @@ class GameState {
       seenArticleUrls: seenArticleUrls ?? this.seenArticleUrls,
       newArticleUrls: newArticleUrls ?? this.newArticleUrls,
       answeredCorrectly: answeredCorrectly ?? this.answeredCorrectly,
+      streak: streak ?? this.streak,
     );
+  }
+
+  /// Returns the streak reward that fired this answer, or null if none.
+  /// Callers can use this to show feedback before reading updated state.
+  StreakReward? pendingStreakReward({required bool correct}) {
+    if (config.gameMode != GameMode.endless || !correct) return null;
+    final nextStreak = streak + 1;
+    if (nextStreak < config.streakLimit) return null;
+    return lives < 3 ? StreakReward.lifeRestored : StreakReward.bonusPoints;
   }
 
   GameState answerQuestion({required bool correct}) {
     final updated = List<bool?>.from(answeredCorrectly);
     updated[currentQuestionIndex] = correct;
-    final newScore = correct ? score + 10 : score;
-    final newLives = correct ? lives : lives - 1;
+
+    int newStreak = correct ? streak + 1 : 0;
+    int newScore = correct ? score + 10 : score;
+    int newLives = correct ? lives : lives - 1;
+
+    if (config.gameMode == GameMode.endless &&
+        correct &&
+        newStreak >= config.streakLimit) {
+      newStreak = 0;
+      if (newLives < 3) {
+        newLives += 1;
+      } else {
+        newScore += config.streakLimit * 10;
+      }
+    }
+
     final isNowGameOver = newLives <= 0;
     final isNowComplete =
         !isNowGameOver && currentQuestionIndex >= questions.length - 1;
@@ -86,6 +116,7 @@ class GameState {
       answeredCorrectly: updated,
       score: newScore,
       lives: newLives,
+      streak: newStreak,
       status: isNowGameOver
           ? GameStatus.gameOver
           : isNowComplete

--- a/lib/features/gameplay/domain/models/quiz_config.dart
+++ b/lib/features/gameplay/domain/models/quiz_config.dart
@@ -17,6 +17,16 @@ class QuizConfig {
 
   static const List<int> validCounts = [5, 10, 20];
 
+  /// Consecutive correct answers required to trigger a streak reward in endless mode.
+  /// Scales with difficulty: easier → shorter streak required.
+  int get streakLimit => switch (difficultyBias) {
+        1 => 5,
+        2 => 7,
+        4 => 13,
+        5 => 15,
+        _ => 10,
+      };
+
   QuizConfig copyWith({
     Set<String>? selectedTopicIds,
     int? questionCount,

--- a/lib/features/gameplay/presentation/screens/gameplay_screen.dart
+++ b/lib/features/gameplay/presentation/screens/gameplay_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../data/topic_registry.dart';
 import '../../domain/models/game_state.dart';
+import '../../domain/models/quiz_config.dart';
 import '../../domain/models/question.dart';
 import '../providers/game_state_provider.dart';
 import '../widgets/answer_button.dart';
@@ -50,9 +51,13 @@ class _GameplayScreenState extends ConsumerState<GameplayScreen> {
 
     final correct = question.isCorrect(index);
     HapticFeedback.mediumImpact();
+    final reward =
+        ref.read(gameStateProvider)?.pendingStreakReward(correct: correct);
     ref.read(gameStateProvider.notifier).answerQuestion(correct: correct);
+    final streakLimit =
+        ref.read(gameStateProvider)?.config.streakLimit ?? 10;
 
-    if (mounted) await _showFunFact(question.funFact, correct);
+    if (mounted) await _showFunFact(question.funFact, correct, reward: reward, streakLimit: streakLimit);
 
     final gs = ref.read(gameStateProvider);
     if (gs == null) return;
@@ -72,7 +77,12 @@ class _GameplayScreenState extends ConsumerState<GameplayScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) => _markPlaying());
   }
 
-  Future<void> _showFunFact(String funFact, bool correct) async {
+  Future<void> _showFunFact(
+    String funFact,
+    bool correct, {
+    StreakReward? reward,
+    int streakLimit = 10,
+  }) async {
     if (!mounted) return;
     await showModalBottomSheet<void>(
       context: context,
@@ -81,7 +91,12 @@ class _GameplayScreenState extends ConsumerState<GameplayScreen> {
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
         side: BorderSide(color: AppColors.stoneMid),
       ),
-      builder: (ctx) => _FunFactSheet(funFact: funFact, correct: correct),
+      builder: (ctx) => _FunFactSheet(
+        funFact: funFact,
+        correct: correct,
+        reward: reward,
+        streakLimit: streakLimit,
+      ),
     );
   }
 
@@ -136,6 +151,8 @@ class _GameplayScreenState extends ConsumerState<GameplayScreen> {
           roomName: topicName(question.topicId),
           score: gs.score,
           lives: gs.lives,
+          streak: gs.streak,
+          isEndless: gs.config.gameMode == GameMode.endless,
         ),
         body: Column(
           children: [
@@ -312,8 +329,15 @@ class _ProgressBar extends StatelessWidget {
 class _FunFactSheet extends StatelessWidget {
   final String funFact;
   final bool correct;
+  final StreakReward? reward;
+  final int streakLimit;
 
-  const _FunFactSheet({required this.funFact, required this.correct});
+  const _FunFactSheet({
+    required this.funFact,
+    required this.correct,
+    this.reward,
+    this.streakLimit = 10,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -337,6 +361,50 @@ class _FunFactSheet extends StatelessWidget {
                               : AppColors.textLight,
                           fontSize: 18))),
             ]),
+            if (reward != null) ...[
+              const SizedBox(height: 10),
+              Container(
+                width: double.infinity,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                decoration: BoxDecoration(
+                  color: reward == StreakReward.lifeRestored
+                      ? AppColors.dangerRed.withValues(alpha: 0.15)
+                      : AppColors.torchGold.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: reward == StreakReward.lifeRestored
+                        ? AppColors.dangerRed
+                        : AppColors.torchGold,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      reward == StreakReward.lifeRestored
+                          ? Icons.favorite
+                          : Icons.bolt,
+                      size: 16,
+                      color: reward == StreakReward.lifeRestored
+                          ? AppColors.dangerRed
+                          : AppColors.torchGold,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      reward == StreakReward.lifeRestored
+                          ? 'Streak! Life restored ❤️'
+                          : 'Streak! +${streakLimit * 10} bonus points ⚡',
+                      style: textTheme.labelMedium?.copyWith(
+                        color: reward == StreakReward.lifeRestored
+                            ? AppColors.dangerRed
+                            : AppColors.torchGold,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
             const SizedBox(height: 14),
             Container(
               width: double.infinity,

--- a/lib/features/gameplay/presentation/widgets/room_header.dart
+++ b/lib/features/gameplay/presentation/widgets/room_header.dart
@@ -5,12 +5,16 @@ class RoomHeader extends StatelessWidget implements PreferredSizeWidget {
   final String roomName;
   final int score;
   final int lives;
+  final int streak;
+  final bool isEndless;
 
   const RoomHeader({
     super.key,
     required this.roomName,
     required this.score,
     required this.lives,
+    this.streak = 0,
+    this.isEndless = false,
   });
 
   @override
@@ -23,6 +27,33 @@ class RoomHeader extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       title: Text(roomName),
       actions: [
+        // Streak chip (endless mode only)
+        if (isEndless && streak > 0) ...[
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: AppColors.stoneDark,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: AppColors.torchGold, width: 1),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.local_fire_department,
+                    size: 14, color: AppColors.torchGold),
+                const SizedBox(width: 3),
+                Text(
+                  '$streak',
+                  style: textTheme.labelLarge?.copyWith(
+                    color: AppColors.torchGold,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+        ],
         // Lives
         Row(
           children: List.generate(

--- a/lib/features/results/presentation/screens/results_screen.dart
+++ b/lib/features/results/presentation/screens/results_screen.dart
@@ -5,8 +5,10 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/theme/app_theme.dart';
 import '../../../gameplay/domain/models/game_state.dart';
+import '../../../gameplay/domain/models/quiz_config.dart';
 import '../../../gameplay/presentation/providers/game_state_provider.dart';
 import '../../../settings/data/game_stats_repository.dart';
+import '../../../settings/domain/models/game_stats.dart';
 
 class ResultsScreen extends ConsumerStatefulWidget {
   const ResultsScreen({super.key});
@@ -17,6 +19,7 @@ class ResultsScreen extends ConsumerStatefulWidget {
 
 class _ResultsScreenState extends ConsumerState<ResultsScreen> {
   bool _statsRecorded = false;
+  GameStats? _savedStats;
 
   @override
   void initState() {
@@ -32,13 +35,16 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
         gs.status == GameStatus.gameOver || gs.status == GameStatus.complete;
     if (!finished) return;
     _statsRecorded = true;
-    await GameStatsRepository.recordGame(
+    final isEndless = gs.config.gameMode == GameMode.endless;
+    final saved = await GameStatsRepository.recordGame(
       score: gs.score,
       correct: gs.correctCount,
       answered: gs.questionsAnswered,
       articlesFound: gs.newArticleUrls.length,
       won: gs.status == GameStatus.complete,
+      endlessScore: isEndless ? gs.score : null,
     );
+    if (mounted) setState(() => _savedStats = saved);
   }
 
   int _starCount(int score, int answered, int total) {
@@ -65,10 +71,13 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
     }
 
     final isGameOver = gs.status == GameStatus.gameOver;
+    final isEndless = gs.config.gameMode == GameMode.endless;
     final answered = gs.questionsAnswered;
     final correct = gs.correctCount;
     final stars = _starCount(gs.score, answered, gs.questions.length);
     final newArticles = gs.newArticleUrls.length;
+    final endlessHighScore = _savedStats?.endlessHighScore ?? 0;
+    final isNewRecord = isEndless && gs.score > 0 && gs.score >= endlessHighScore;
 
     return Scaffold(
       body: Stack(
@@ -174,6 +183,15 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
                           value: '$newArticles',
                           delay: 950,
                           valueColor: AppColors.torchGold),
+                    if (isEndless && _savedStats != null)
+                      _StatRow(
+                          icon: Icons.emoji_events,
+                          label: isNewRecord ? 'New Record! 🏆' : 'Endless Best',
+                          value: '$endlessHighScore',
+                          delay: 1050,
+                          valueColor: isNewRecord
+                              ? AppColors.torchGold
+                              : AppColors.torchAmber),
                   ].expand((w) => [w, const SizedBox(height: 10)]).toList()
                     ..removeLast(),
 

--- a/lib/features/settings/data/game_stats_repository.dart
+++ b/lib/features/settings/data/game_stats_repository.dart
@@ -27,6 +27,7 @@ class GameStatsRepository {
     required int answered,
     required int articlesFound,
     required bool won,
+    int? endlessScore,
   }) async {
     final current = await load();
     final updated = current.recordGame(
@@ -35,6 +36,7 @@ class GameStatsRepository {
       answered: answered,
       articlesFound: articlesFound,
       won: won,
+      endlessScore: endlessScore,
     );
     await save(updated);
     return updated;

--- a/lib/features/settings/domain/models/game_stats.dart
+++ b/lib/features/settings/domain/models/game_stats.dart
@@ -6,6 +6,7 @@ class GameStats {
   final int totalCorrect;
   final int totalAnswered;
   final int totalArticlesFound;
+  final int endlessHighScore;
 
   const GameStats({
     this.gamesPlayed = 0,
@@ -15,6 +16,7 @@ class GameStats {
     this.totalCorrect = 0,
     this.totalAnswered = 0,
     this.totalArticlesFound = 0,
+    this.endlessHighScore = 0,
   });
 
   double get accuracy =>
@@ -29,6 +31,7 @@ class GameStats {
     required int answered,
     required int articlesFound,
     required bool won,
+    int? endlessScore,
   }) {
     return GameStats(
       gamesPlayed: gamesPlayed + 1,
@@ -38,6 +41,9 @@ class GameStats {
       totalCorrect: totalCorrect + correct,
       totalAnswered: totalAnswered + answered,
       totalArticlesFound: totalArticlesFound + articlesFound,
+      endlessHighScore: endlessScore != null && endlessScore > endlessHighScore
+          ? endlessScore
+          : endlessHighScore,
     );
   }
 
@@ -49,6 +55,7 @@ class GameStats {
         'totalCorrect': totalCorrect,
         'totalAnswered': totalAnswered,
         'totalArticlesFound': totalArticlesFound,
+        'endlessHighScore': endlessHighScore,
       };
 
   factory GameStats.fromJson(Map<String, dynamic> json) => GameStats(
@@ -59,5 +66,6 @@ class GameStats {
         totalCorrect: (json['totalCorrect'] as int?) ?? 0,
         totalAnswered: (json['totalAnswered'] as int?) ?? 0,
         totalArticlesFound: (json['totalArticlesFound'] as int?) ?? 0,
+        endlessHighScore: (json['endlessHighScore'] as int?) ?? 0,
       );
 }

--- a/lib/features/start/presentation/screens/topic_picker_screen.dart
+++ b/lib/features/start/presentation/screens/topic_picker_screen.dart
@@ -10,6 +10,7 @@ import '../../../gameplay/domain/models/quiz_config.dart';
 import '../../../gameplay/domain/models/topic.dart';
 import '../../../gameplay/presentation/providers/game_state_provider.dart';
 import '../../../gameplay/presentation/providers/quiz_config_provider.dart';
+import '../../../settings/data/game_stats_repository.dart';
 
 class TopicPickerScreen extends ConsumerStatefulWidget {
   const TopicPickerScreen({super.key});
@@ -23,6 +24,7 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
   int _questionCount = 10;
   GameMode _gameMode = GameMode.standard;
   int _difficultyBias = 3;
+  int _endlessHighScore = 0;
 
   @override
   void initState() {
@@ -32,6 +34,12 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
     _questionCount = config.questionCount;
     _gameMode = config.gameMode;
     _difficultyBias = config.difficultyBias;
+    _loadEndlessHighScore();
+  }
+
+  Future<void> _loadEndlessHighScore() async {
+    final stats = await GameStatsRepository.load();
+    if (mounted) setState(() => _endlessHighScore = stats.endlessHighScore);
   }
 
   bool get _canStart =>
@@ -165,6 +173,7 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
             gameMode: _gameMode,
             difficultyBias: _difficultyBias,
             canStart: _canStart,
+            endlessHighScore: _endlessHighScore,
             onCountChanged: (c) => setState(() => _questionCount = c),
             onModeChanged: (m) => setState(() => _gameMode = m),
             onDifficultyChanged: (b) => setState(() => _difficultyBias = b),
@@ -385,6 +394,7 @@ class _BottomBar extends StatelessWidget {
   final GameMode gameMode;
   final int difficultyBias;
   final bool canStart;
+  final int endlessHighScore;
   final void Function(int) onCountChanged;
   final void Function(GameMode) onModeChanged;
   final void Function(int) onDifficultyChanged;
@@ -396,6 +406,7 @@ class _BottomBar extends StatelessWidget {
     required this.gameMode,
     required this.difficultyBias,
     required this.canStart,
+    required this.endlessHighScore,
     required this.onCountChanged,
     required this.onModeChanged,
     required this.onDifficultyChanged,
@@ -443,6 +454,17 @@ class _BottomBar extends StatelessWidget {
               ),
             ],
           ),
+          const SizedBox(height: 6),
+
+          // Endless best score
+          if (isEndless && endlessHighScore > 0)
+            Text(
+              'Best: $endlessHighScore pts',
+              style: textTheme.labelMedium?.copyWith(
+                color: AppColors.torchGold,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
           const SizedBox(height: 10),
 
           // Question count (hidden in endless mode)

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,6 +5,9 @@
 ### Features
 - User profile page — set a display name, pick an emoji avatar, and optionally link a GitHub profile; display name and emoji now sign all feedback submissions (#78)
 - Game stats in Settings — cumulative stats (games played, best score, win rate, accuracy, total articles found) are recorded after each game and shown on the Settings screen (#78)
+- Endless mode streak counter — a 🔥 streak chip appears in the header while you maintain a correct-answer streak; streak limit scales with difficulty (easy 5 → hard 15) (#74)
+- Endless mode life recovery — reaching the streak limit restores one life if you have fewer than three; if lives are full, the milestone awards streak-limit × 10 bonus points instead (#74)
+- Endless mode high score — your best score is saved and shown on the results screen ("Endless Best" / "New Record!") and on the topic picker when endless mode is selected (#57)
 
 ### Fixes
 - App icon no longer shows as a small image inside a white circle on Android 8.0+ devices — added adaptive icon configuration (`mipmap-anydpi-v26`) with the castle dark background (#66)


### PR DESCRIPTION
Closes #57
Closes #74

## What's in this PR

### Streak counter (#74)
- `GameState` gains a `streak` field — increments on each correct answer, resets to 0 on a wrong answer
- A 🔥 streak chip appears in the `RoomHeader` during endless mode whenever streak > 0

### Life recovery & bonus points (#74)
- `QuizConfig.streakLimit` scales with difficulty bias: 1→5, 2→7, 3→10, 4→13, 5→15
- When streak hits `streakLimit` in endless mode:
  - lives < 3 → restore 1 life, streak resets
  - lives full → award `streakLimit × 10` bonus points, streak resets
- The fun-fact bottom sheet shows a highlighted banner ("Life restored ❤️" or "+N bonus points ⚡") when a milestone fires

### Endless high score (#57)
- `GameStats` gains an `endlessHighScore` field (persisted via SharedPreferences, backwards-compatible JSON)
- Results screen shows an "Endless Best" stat row for endless games; upgrades to "New Record! 🏆" when the current run beats the saved best
- Topic picker shows "Best: N pts" below the mode toggle when endless mode is selected and a high score exists

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes
- [ ] Endless mode: streak chip appears and increments correctly
- [ ] Streak milestone restores a life when lives < 3; awards bonus points when lives = 3
- [ ] Fun-fact sheet shows the correct reward banner
- [ ] Results screen shows "Endless Best" / "New Record!" after an endless game
- [ ] Topic picker shows "Best: N pts" when endless mode is selected after a game

https://claude.ai/code/session_019J3eLww8K3bswuAgRpByWb