### PR TITLE
feat: issues view UX improvements (#82)

### DIFF
--- a/ai/tasks/release-roadmap/plan.md
+++ b/ai/tasks/release-roadmap/plan.md
@@ -1,0 +1,170 @@
+# Plan: Release Roadmap — Triaged Issues (excl. #82)
+
+## Context
+Eight triaged alpha-feedback issues need to be worked through in a logical release order. They range from trivial UI bugs to a major UX redesign of the home flow. This plan groups them into four sequential releases, each independently shippable, with infrastructure work (responsive layout, settings) landing before features that depend on it.
+
+---
+
+## Issues in Scope
+
+| Issue | Title | Type | Release |
+|-------|-------|------|---------|
+| #54 | Long text wrapping on answer buttons | UI bug | A — v1.1 |
+| #83 | Game stats inaccurate (win rate + articles = 0) | Bug | A — v1.1 |
+| #63 | App permissions audit | Improvement | A — v1.1 |
+| #55 | Wiki link in answer result popup | UI feature | B — v1.2 |
+| #56 | Question bank: negative URL counts + content request popup | Bug + feature | B — v1.2 |
+| #62 | Flexible/responsive scaling (all screens) | Cross-cutting | B — v1.2 |
+| #59 | About page + first-visit tooltips + app settings | New screens | C — v1.3 |
+| #58 | Game mode selection redesign (home flow) | Major feature | D — v1.4 |
+
+---
+
+## Release A — v1.1: Bug Fix Sprint
+
+**Goal:** Eliminate the most visible defects reported by alpha testers with low-risk, isolated changes.
+
+### #54 — Long text wrapping
+- **File:** `lib/features/gameplay/presentation/widgets/answer_button.dart`
+- **Fix:** Ensure the `Text` inside `Expanded` has no external height cap (`maxLines`, fixed height container); `softWrap: true` is default. Investigate caller in `gameplay_screen.dart` for any fixed-height `SizedBox` or `ConstrainedBox` wrapping answer buttons.
+- **Skill:** `fix-bug`
+
+### #83 — Game stats inaccurate
+- **Root cause investigation needed first** (use `investigate-issue`)
+- Likely causes:
+  1. `articlesFound: gs.newArticleUrls.length` — counts only *newly discovered* articles per session; articles already opened before count as 0
+  2. Win rate is 0 in Endless because `won: gs.status == GameStatus.complete` never fires for Endless games that end via `gameOver`
+- **Files:** `lib/features/results/presentation/screens/results_screen.dart`, `lib/features/settings/domain/models/game_stats.dart`, `lib/features/settings/data/game_stats_repository.dart`
+- **Fix options:**
+  - Fix articles tracking: count all articles opened in session (not just new ones), or clarify the label
+  - Fix Endless win recording: define what a "win" means for Endless (e.g. any completed session, or a score milestone)
+  - Add mode-scoped label: "Standard Win Rate" if win rate only counts Standard games
+- **Skill:** `investigate-issue` → `fix-bug`
+
+### #63 — App permissions
+- **Audit:** `android/app/src/main/AndroidManifest.xml` — check declared permissions vs actual usage
+- App uses: internet (WebView) — INTERNET is a normal permission, no runtime dialog needed
+- Check: vibration (used by `flutter_animate` shake?), camera (not used), storage (not used)
+- Remove any over-declared permissions; add rationale if any dangerous permission is needed
+- **Skill:** `implement-feature`
+
+---
+
+## Release B — v1.2: Gameplay UX
+
+**Goal:** Improve the in-game experience and developer-facing question bank; make all existing screens responsive.
+
+### #55 — Wiki link in answer popup
+- Find the `answerRevealed` phase overlay in `lib/features/gameplay/presentation/screens/gameplay_screen.dart`
+- Add a "Read article" button that pushes `/article` with the current question's wiki URL
+- Button should only appear if the question has a wiki URL
+- **Skill:** `implement-feature`
+
+### #56 — Question bank display + content request
+- **Part 1 (bug):** Negative URL counts in `lib/features/start/presentation/screens/question_stats_screen.dart` — trace calculation and fix
+- **Part 2 (feature):** Wrap each list row with `GestureDetector` → show a `showModalBottomSheet` form with:
+  - Field: "New sources to request" (number)
+  - Field: "New questions to request" (number)
+  - Submit → write a `ContentRequest` entry to a local list (or SharedPreferences log) + show a confirmation snackbar
+- **Skill:** `fix-bug` (Part 1) then `implement-feature` (Part 2)
+
+### #62 — Flexible/responsive scaling
+- **Audit:** identify all hardcoded pixel values in layout widgets
+- **Strategy:** use `MediaQuery.of(context).size` or `LayoutBuilder` to scale padding/font sizes; avoid third-party ScreenUtil unless already in pubspec
+- **Screens to fix:** `StartScreen`, `TopicPickerScreen`, `GameplayScreen`, `ResultsScreen`, `QuestionCard`, `AnswerButton`, `RoomHeader`, `QuestionStatsScreen`
+- **Test points:** 360dp (Pixel 6), 412dp (Pixel 9, baseline), 480dp (large phone), 600dp+ (tablet)
+- **Key rule:** no hardcoded sizes in new widgets; use `Theme.of(context).textTheme` scales and fractional padding
+- **Skill:** `implement-feature`
+
+---
+
+## Release C — v1.3: Onboarding & Settings
+
+**Goal:** Help new users learn the game; establish the settings infrastructure needed by the mode redesign in D.
+
+### #59 — About page + first-visit tooltips + app settings
+- **New route:** `/about` — `AboutScreen` with "How to Play" content (rooms, lives, scoring, streak, wiki)
+- **New route:** `/settings` — `AppSettingsScreen` with at minimum:
+  - "Show gameplay tips" toggle (persisted via `SharedPreferences`)
+- **First-visit coach marks:**
+  - Store visited-screens set in `SharedPreferences` (key: `visited_screens_v1`)
+  - On first visit to `/game` and `/results`, show an `OverlayEntry` coach mark or `TutorialCoachMark` package
+  - Dismissed permanently once user taps "Got it"
+- **Settings icon:** add to `StartScreen` AppBar → navigates to `/settings`
+- **About link:** add to `/settings` or directly accessible from `StartScreen`
+- **Skill:** `implement-feature`
+
+---
+
+## Release D — v1.4: Mode Selection Redesign
+
+**Goal:** Replace the topic picker with a proper game-mode selection experience, surfacing Standard vs Endless clearly.
+
+### #58 — Game mode selection
+- **Replace:** `TopicPickerScreen` (or demote it to a sub-screen within mode settings)
+- **New screen:** `ModeSelectionScreen` as the landing after "Play" on `StartScreen`
+- **UI:** two large cards side-by-side (or stacked):
+  - Standard — image: castle doors; subtitle: "Answer a set number of questions"
+  - Endless — image: dark corridor or infinity symbol; subtitle: "Keep going until you fall"
+- **Settings modal per mode** (bottom sheet or dialog):
+  - Common: difficulty picker, topic multi-select
+  - Standard only: question count slider/picker (5 / 10 / 15 / 20)
+- **Wire up:** tapping "Play" on a mode card + confirming settings → pushes to `/game` with the configured `QuizConfig`
+- **GoRouter:** new route `/modes`; update `/` → Play button → `/modes` instead of direct to `/game`
+- **Skill:** `implement-feature`
+
+---
+
+## Order of Operations
+
+1. **A1** — Investigate #83 (stats bug root cause) with `investigate-issue`
+2. **A2** — Fix #54 (text wrapping) with `fix-bug`
+3. **A3** — Fix #83 (stats) with `fix-bug` (informed by A1)
+4. **A4** — Audit + fix #63 (permissions) with `implement-feature`
+5. **A5** — PR, release v1.1
+6. **B1** — Implement #55 (wiki in popup) with `implement-feature`
+7. **B2** — Fix + extend #56 (question bank) with `fix-bug` + `implement-feature`
+8. **B3** — Implement #62 (responsive scaling) with `implement-feature` — test on emulated sizes
+9. **B4** — PR, release v1.2
+10. **C1** — Implement #59 (about + tooltips + settings) with `implement-feature`
+11. **C2** — PR, release v1.3
+12. **D1** — Implement #58 (mode selection redesign) with `implement-feature`
+13. **D2** — PR, release v1.4
+
+---
+
+## Files to Create / Modify
+
+| File | Action | Release |
+|------|--------|---------|
+| `lib/features/gameplay/presentation/widgets/answer_button.dart` | Fix text height constraints | A |
+| `lib/features/gameplay/presentation/screens/gameplay_screen.dart` | Fix answer button height + add wiki button to answer reveal | A, B |
+| `lib/features/results/presentation/screens/results_screen.dart` | Fix articlesFound + win tracking | A |
+| `lib/features/settings/domain/models/game_stats.dart` | Add mode-scoped win tracking or label fix | A |
+| `android/app/src/main/AndroidManifest.xml` | Audit permissions | A |
+| `lib/features/start/presentation/screens/question_stats_screen.dart` | Fix URL count display + add row tap + bottom sheet | B |
+| All layout widgets (see #62 scope) | Replace hardcoded sizes | B |
+| `lib/features/start/presentation/screens/start_screen.dart` | Add settings icon | C |
+| `lib/features/settings/presentation/screens/app_settings_screen.dart` | Create new | C |
+| `lib/features/start/presentation/screens/about_screen.dart` | Create new | C |
+| `lib/core/router/` or `lib/app.dart` | Add `/about`, `/settings`, `/modes` routes | C, D |
+| `lib/features/start/presentation/screens/mode_selection_screen.dart` | Create new | D |
+| `lib/features/start/presentation/widgets/mode_card.dart` | Create new | D |
+
+---
+
+## Verification
+
+```bash
+# After each release group
+flutter analyze --fatal-infos
+flutter test --reporter expanded
+
+# Manual test matrix for #62
+# Run on: Android emulator 360dp (Pixel 6a), 412dp (Pixel 9), 600dp (tablet)
+# Check: no overflow, no clipped text, all buttons tappable
+
+# After #83 fix
+# Play a game, open 2 articles, finish → check stats screen shows correct counts
+# Play Endless game → check win rate / stats update appropriately
+```

--- a/ai/tasks/release-roadmap/proposal/01-release-grouping.md
+++ b/ai/tasks/release-roadmap/proposal/01-release-grouping.md
@@ -1,0 +1,75 @@
+# Proposal 01 — Release Grouping Strategy
+
+## Principles
+
+1. **Bug fixes and polish first** — low risk, immediate value for alpha testers
+2. **Infrastructure before features** — responsive layout (#62) and settings foundations (#59) before new screens (#58)
+3. **Each release is shippable** — no release depends on unfinished work from the next one
+4. **Largest scope last** — #58 (mode redesign) touches the most code; doing it last means all other improvements are already stable
+
+---
+
+## Release Groups
+
+### Release A — v1.1: Bug Fix Sprint
+**Goal:** Fix the most visible defects reported by alpha testers
+
+| Issue | Title | Why here |
+|-------|-------|----------|
+| #54 | Long text wrapping | Trivial isolated fix; embarrassing to ship with |
+| #83 | Game stats inaccurate | Trust/data correctness issue; easy win once root cause found |
+| #63 | App permissions | Defensive hygiene; small diff |
+
+**Estimated PRs:** 1–3 small PRs
+**Risk:** Very low — all isolated fixes
+
+---
+
+### Release B — v1.2: Gameplay UX
+**Goal:** Improve the in-game and question-bank experience
+
+| Issue | Title | Why here |
+|-------|-------|----------|
+| #55 | Wiki link in answer popup | Small contained addition to existing overlay |
+| #56 | Question bank: URL counts + request popup | Fixes a confusing display + adds useful UX for question management |
+| #62 | Flexible/responsive scaling | Must ship before new screens; fixes existing screens immediately |
+
+**Estimated PRs:** 2–3 PRs
+**Risk:** Low–medium (#62 touches many widgets; needs broad testing)
+
+---
+
+### Release C — v1.3: Onboarding & Settings
+**Goal:** Help new users understand the game; establish settings infrastructure
+
+| Issue | Title | Why here |
+|-------|-------|----------|
+| #59 | About page + tooltips + app settings | New screens built on responsive layout from B; settings persistence pattern needed by #58 |
+
+**Estimated PRs:** 1 PR (can be split by sub-feature)
+**Risk:** Medium — new navigation routes + SharedPreferences usage
+**Dependency:** Release B (#62) shipped
+
+---
+
+### Release D — v1.4: Mode Selection Redesign
+**Goal:** Replace the topic picker with a proper game mode selection experience
+
+| Issue | Title | Why here |
+|-------|-------|----------|
+| #58 | Game mode selection (home flow) | Largest change; builds on responsive layout + settings; comes last to avoid destabilising earlier work |
+
+**Estimated PRs:** 1–2 PRs
+**Risk:** High — replaces the primary navigation flow into a game
+**Dependency:** Releases B + C shipped
+
+---
+
+## Timeline overview
+
+```
+A: v1.1 ─── Bug Fix Sprint     → #54, #83, #63
+B: v1.2 ─── Gameplay UX        → #55, #56, #62
+C: v1.3 ─── Onboarding/Settings→ #59
+D: v1.4 ─── Mode Redesign      → #58
+```

--- a/ai/tasks/release-roadmap/research/issue-analysis.md
+++ b/ai/tasks/release-roadmap/research/issue-analysis.md
@@ -1,0 +1,82 @@
+# Issue Analysis — Triaged Issues (excl. #82)
+
+## Issues in scope
+
+| # | Title | Type | Complexity |
+|---|-------|------|------------|
+| 54 | Long text wrapping on answer buttons | UI bug | XS |
+| 55 | Wiki link in answer result popup | UI feature | S |
+| 56 | Question bank: negative URL counts + content request popup | Bug + feature | M |
+| 58 | Game mode selection redesign (home flow) | Major feature | XL |
+| 59 | About page + tooltips + app settings | New screens | L |
+| 62 | Flexible/responsive scaling (all screens) | Cross-cutting | L |
+| 63 | App permissions audit and implementation | Platform + UI | S |
+| 83 | Game stats inaccurate (win rate + articles = 0) | Bug | S |
+
+---
+
+## Issue detail notes
+
+### #54 — Long text wrapping
+- `answer_button.dart` already uses `Expanded` wrapping a `Text` with no `overflow` or `maxLines` constraint
+- Bug is likely a fixed height constraint applied by the caller in `gameplay_screen.dart`
+- Fix: remove/relax height constraints; ensure `Text` has `softWrap: true` (default)
+
+### #55 — Wiki link in answer popup
+- After answering, `GameStatus.answerRevealed` state is shown with a result overlay
+- Need to find that overlay widget and add a "Read article" button that navigates to `/article` with the current question's wiki URL
+- Does not affect gameplay flow, just the `answerRevealed` phase
+
+### #56 — Question bank display bug + content request
+- The question stats screen (`question_stats_screen.dart`) shows negative URL counts
+- Need to trace how counts are calculated and fix the display logic
+- Content request popup: add `GestureDetector` on list rows → bottom sheet form (sources count + questions count)
+
+### #58 — Game mode selection redesign
+- Replace `topic_picker_screen.dart` as the post-home navigation target
+- Add a new `ModeSelectionScreen` with Standard card and Endless card
+- Each card has a settings modal (difficulty, topics; Standard also has question count)
+- Standard mode already exists; Endless already exists — this is a UX entry point, not new game logic
+- **Depends on #59** having established settings persistence patterns
+
+### #59 — About page + tooltips + app settings
+- New `AboutScreen` accessible from home/settings icon
+- First-visit coach mark system: use `SharedPreferences` to track which screens have been visited; show overlay on first visit
+- `AppSettingsScreen` with "Disable tips" toggle (persisted)
+- Settings icon on `StartScreen` needed
+- **Establishes settings persistence pattern used by #58**
+
+### #62 — Flexible scaling
+- App designed for Pixel 9 (412dp wide); needs to work from Pixel 6 (360dp) to tablets (600dp+)
+- Use `LayoutBuilder` / `MediaQuery` for responsive constraints
+- Replace any hardcoded pixel dimensions with `% of screen` or `ScreenUtil`-style fractions
+- Affects: `StartScreen`, `GameplayScreen`, `ResultsScreen`, `QuestionCard`, `AnswerButton`, `RoomHeader`
+- Should be done before building new screens in #58 and #59 so new screens are responsive from birth
+
+### #63 — App permissions
+- Audit `AndroidManifest.xml` for declared permissions
+- App uses: internet (WebView), possibly vibration (shake animation)
+- Android 6+ requires runtime permission for dangerous permissions; internet is a normal permission (no runtime dialog needed)
+- Check if any permissions are missing or over-declared; add rationale dialogs if needed
+
+### #83 — Game stats inaccurate
+- `results_screen.dart:43` → `articlesFound: gs.newArticleUrls.length`
+- `newArticleUrls` is populated when user opens an article the app hasn't seen before; if all articles were previously opened they count as 0
+- Win rate: `won: gs.status == GameStatus.complete` — in Endless mode the game ends via `GameStatus.gameOver` (lives run out) or is potentially never "won"; `totalWins` will never increment for Endless
+- **Fix needed**: clarify what "win" means in Endless (possibly a high score milestone), and clarify articles tracking
+- **UX fix**: label win rate as "Standard Mode Win Rate" if it's mode-scoped
+
+---
+
+## Key dependencies
+
+```
+#54 → none (standalone bug)
+#83 → none (standalone bug)
+#63 → none (audit + small fix)
+#55 → none (contained to gameplay answer overlay)
+#56 → none (contained to question bank screen)
+#62 → none but SHOULD run before #59 and #58
+#59 → #62 (build new screens responsively)
+#58 → #59 (uses settings persistence) + #62 (responsive from start)
+```

--- a/lib/features/feedback/data/github_issue_service.dart
+++ b/lib/features/feedback/data/github_issue_service.dart
@@ -28,6 +28,13 @@ enum ContentRequestType {
   final String label;
 }
 
+enum IssueSort {
+  /// Sort by issue number (created date descending) — default.
+  byNumber,
+  /// Sort by latest activity (updated date descending).
+  byActivity,
+}
+
 /// A minimal view of a GitHub issue returned by [GithubIssueService.fetchOpenIssues].
 class IssueItem {
   final int number;
@@ -35,6 +42,9 @@ class IssueItem {
   final String body;
   final List<String> labelNames;
   final DateTime createdAt;
+  final DateTime updatedAt;
+  final int commentCount;
+  final String? linkedPrUrl;
 
   const IssueItem({
     required this.number,
@@ -42,7 +52,13 @@ class IssueItem {
     required this.body,
     required this.labelNames,
     required this.createdAt,
+    required this.updatedAt,
+    required this.commentCount,
+    this.linkedPrUrl,
   });
+
+  /// Whether this entry is a pull request (GitHub returns PRs via the issues endpoint).
+  bool get isPullRequest => linkedPrUrl != null;
 
   factory IssueItem.fromJson(Map<String, dynamic> json) => IssueItem(
         number: json['number'] as int,
@@ -52,6 +68,10 @@ class IssueItem {
             .map((l) => l['name'] as String)
             .toList(),
         createdAt: DateTime.parse(json['created_at'] as String),
+        updatedAt: DateTime.parse(json['updated_at'] as String),
+        commentCount: (json['comments'] as int?) ?? 0,
+        // 'pull_request' key is present when the item itself is a PR.
+        linkedPrUrl: (json['pull_request'] as Map<String, dynamic>?)?['html_url'] as String?,
       );
 }
 
@@ -164,21 +184,29 @@ ${attribution != null ? '**Submitted by:** $attribution\n' : userId != null ? '*
     );
   }
 
-  /// Fetches open issues tagged with [alpha-feedback] (most recent first).
-  static Future<List<IssueItem>> fetchOpenIssues({int perPage = 30}) async {
+  /// Fetches open issues tagged with [alpha-feedback].
+  ///
+  /// [sort] controls ordering: by issue number (default) or latest activity.
+  static Future<List<IssueItem>> fetchOpenIssues({
+    int perPage = 50,
+    IssueSort sort = IssueSort.byNumber,
+  }) async {
     if (_kGithubToken.isEmpty) return [];
     try {
+      final sortParam = sort == IssueSort.byActivity ? 'updated' : 'created';
       final uri = Uri.parse(
         'https://api.github.com/repos/$_kRepoOwner/$_kRepoName/issues'
-        '?state=open&labels=alpha-feedback&per_page=$perPage&sort=created&direction=desc',
+        '?state=open&labels=alpha-feedback&per_page=$perPage&sort=$sortParam&direction=desc',
       );
       final response = await _client
           .get(uri, headers: _headers)
           .timeout(const Duration(seconds: 15));
       if (response.statusCode != 200) return [];
       final list = jsonDecode(response.body) as List;
+      // GitHub API may return pull requests in the issues endpoint — exclude them.
       return list
           .map((j) => IssueItem.fromJson(j as Map<String, dynamic>))
+          .where((item) => item.linkedPrUrl == null)
           .toList();
     } catch (_) {
       return [];
@@ -206,16 +234,59 @@ ${attribution != null ? '**Submitted by:** $attribution\n' : userId != null ? '*
     }
   }
 
+  /// Returns the set of issue numbers that have at least one open PR referencing them.
+  ///
+  /// Parses `Closes #N`, `Fixes #N`, `Resolves #N`, and bare `#N` patterns
+  /// from open PR titles and bodies.
+  static Future<Set<int>> fetchIssueNumbersWithOpenPr() async {
+    if (_kGithubToken.isEmpty) return {};
+    try {
+      final uri = Uri.parse(
+        'https://api.github.com/repos/$_kRepoOwner/$_kRepoName/pulls'
+        '?state=open&per_page=50',
+      );
+      final response = await _client
+          .get(uri, headers: _headers)
+          .timeout(const Duration(seconds: 15));
+      if (response.statusCode != 200) return {};
+      final prs = jsonDecode(response.body) as List;
+      final referenced = <int>{};
+      final pattern = RegExp(r'(?:closes?|fixes?|resolves?|#)\s*#?(\d+)', caseSensitive: false);
+      for (final pr in prs) {
+        final title = (pr['title'] as String?) ?? '';
+        final body = (pr['body'] as String?) ?? '';
+        for (final text in [title, body]) {
+          for (final match in pattern.allMatches(text)) {
+            final n = int.tryParse(match.group(1)!);
+            if (n != null) referenced.add(n);
+          }
+        }
+      }
+      return referenced;
+    } catch (_) {
+      return {};
+    }
+  }
+
   /// Adds a comment to an existing issue. Returns true on success.
+  ///
+  /// [attribution] — formatted display name (e.g. "🧙 Ada"); used when set.
+  /// [userId] — fallback anonymous ID when [attribution] is null.
   static Future<bool> addComment({
     required int issueNumber,
     required String body,
+    String? attribution,
     String? userId,
   }) async {
     if (_kGithubToken.isEmpty) return false;
-    final commentBody = userId != null
-        ? '$body\n\n---\n**User ID:** `$userId`'
-        : body;
+    final String commentBody;
+    if (attribution != null) {
+      commentBody = '$body\n\n---\n**Submitted by:** $attribution';
+    } else if (userId != null) {
+      commentBody = '$body\n\n---\n**User ID:** `$userId`';
+    } else {
+      commentBody = body;
+    }
     try {
       final response = await _client
           .post(

--- a/lib/features/feedback/data/github_issue_service.dart
+++ b/lib/features/feedback/data/github_issue_service.dart
@@ -68,7 +68,9 @@ class IssueItem {
             .map((l) => l['name'] as String)
             .toList(),
         createdAt: DateTime.parse(json['created_at'] as String),
-        updatedAt: DateTime.parse(json['updated_at'] as String),
+        updatedAt: json['updated_at'] != null
+            ? DateTime.parse(json['updated_at'] as String)
+            : DateTime.parse(json['created_at'] as String),
         commentCount: (json['comments'] as int?) ?? 0,
         // 'pull_request' key is present when the item itself is a PR.
         linkedPrUrl: (json['pull_request'] as Map<String, dynamic>?)?['html_url'] as String?,

--- a/lib/features/feedback/presentation/screens/feedback_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 
 import 'package:package_info_plus/package_info_plus.dart';
 
@@ -107,7 +108,7 @@ class _FeedbackScreenState extends State<FeedbackScreen>
             onLoadDraft: _loadDraft,
             onDraftDeleted: _onDraftSaved,
           ),
-          _IssuesTab(userId: _profile?.userId),
+          _IssuesTab(profile: _profile),
         ],
       ),
     );
@@ -873,8 +874,8 @@ class _PendingFeedbackTabState extends State<_PendingFeedbackTab> {
 // ---------------------------------------------------------------------------
 
 class _IssuesTab extends StatefulWidget {
-  final String? userId;
-  const _IssuesTab({this.userId});
+  final UserProfile? profile;
+  const _IssuesTab({this.profile});
 
   @override
   State<_IssuesTab> createState() => _IssuesTabState();
@@ -882,7 +883,12 @@ class _IssuesTab extends StatefulWidget {
 
 class _IssuesTabState extends State<_IssuesTab>
     with AutomaticKeepAliveClientMixin {
-  late Future<List<IssueItem>> _issuesFuture;
+  List<IssueItem> _issues = [];
+  Set<int> _issuesWithPr = {};
+  bool _loading = true;
+
+  IssueSort _sort = IssueSort.byNumber;
+  String? _activeLabel;
 
   @override
   bool get wantKeepAlive => true;
@@ -890,7 +896,25 @@ class _IssuesTabState extends State<_IssuesTab>
   @override
   void initState() {
     super.initState();
-    _issuesFuture = GithubIssueService.fetchOpenIssues();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final results = await Future.wait([
+      GithubIssueService.fetchOpenIssues(sort: _sort),
+      GithubIssueService.fetchIssueNumbersWithOpenPr(),
+    ]);
+    if (!mounted) return;
+    setState(() {
+      _issues = results[0] as List<IssueItem>;
+      _issuesWithPr = results[1] as Set<int>;
+      _loading = false;
+    });
+  }
+
+  Future<void> _refresh() async {
+    await _load();
   }
 
   void _openDetail(IssueItem issue) {
@@ -901,92 +925,403 @@ class _IssuesTabState extends State<_IssuesTab>
       useSafeArea: true,
       shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(16))),
-      builder: (ctx) => _IssueDetailSheet(issue: issue, userId: widget.userId),
+      builder: (ctx) => _IssueDetailSheet(issue: issue, profile: widget.profile),
     );
+  }
+
+  List<String> get _allLabels {
+    final labels = <String>{};
+    for (final issue in _issues) {
+      labels.addAll(issue.labelNames);
+    }
+    return labels.toList()..sort();
+  }
+
+  List<IssueItem> get _filtered {
+    if (_activeLabel == null) return _issues;
+    return _issues.where((i) => i.labelNames.contains(_activeLabel)).toList();
   }
 
   @override
   Widget build(BuildContext context) {
     super.build(context);
     final tt = Theme.of(context).textTheme;
-    return FutureBuilder<List<IssueItem>>(
-      future: _issuesFuture,
-      builder: (context, snap) {
-        if (snap.connectionState != ConnectionState.done) {
-          return const Center(child: CircularProgressIndicator());
-        }
-        final issues = snap.data ?? [];
-        if (issues.isEmpty) {
-          return Center(
-            child: Padding(
-              padding: const EdgeInsets.all(32),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.list_alt_outlined,
-                      size: 48,
-                      color: AppColors.textLight.withValues(alpha: 0.3)),
-                  const SizedBox(height: 16),
-                  Text(
-                    'No open issues',
-                    style: tt.titleMedium?.copyWith(
-                        color: AppColors.textLight.withValues(alpha: 0.5)),
+
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final filtered = _filtered;
+
+    return Column(
+      children: [
+        // Sort + filter toolbar
+        _IssuesToolbar(
+          sort: _sort,
+          allLabels: _allLabels,
+          activeLabel: _activeLabel,
+          onSortChanged: (s) {
+            setState(() {
+              _sort = s;
+              _activeLabel = null;
+            });
+            _load();
+          },
+          onLabelChanged: (l) => setState(() => _activeLabel = l),
+        ),
+        // Issue list with pull-to-refresh
+        Expanded(
+          child: RefreshIndicator(
+            color: AppColors.torchAmber,
+            backgroundColor: AppColors.stone,
+            onRefresh: _refresh,
+            child: filtered.isEmpty
+                ? ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    children: [
+                      SizedBox(
+                        height: 300,
+                        child: Center(
+                          child: Padding(
+                            padding: const EdgeInsets.all(32),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.list_alt_outlined,
+                                    size: 48,
+                                    color: AppColors.textLight.withValues(alpha: 0.3)),
+                                const SizedBox(height: 16),
+                                Text(
+                                  _activeLabel != null
+                                      ? 'No issues with label "$_activeLabel"'
+                                      : 'No open issues',
+                                  style: tt.titleMedium?.copyWith(
+                                      color: AppColors.textLight.withValues(alpha: 0.5)),
+                                ),
+                                if (_activeLabel == null) ...[
+                                  const SizedBox(height: 8),
+                                  Text(
+                                    'No open alpha-feedback issues found, or unable to reach GitHub.',
+                                    textAlign: TextAlign.center,
+                                    style: tt.bodySmall?.copyWith(
+                                        color: AppColors.textLight.withValues(alpha: 0.35)),
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  )
+                : ListView.separated(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.only(bottom: 16),
+                    itemCount: filtered.length,
+                    separatorBuilder: (_, __) => const Divider(
+                        color: AppColors.stoneMid, height: 1, indent: 56),
+                    itemBuilder: (context, i) {
+                      final issue = filtered[i];
+                      final hasPr = _issuesWithPr.contains(issue.number);
+                      return _IssueListTile(
+                        issue: issue,
+                        hasPr: hasPr,
+                        onTap: () => _openDetail(issue),
+                      );
+                    },
                   ),
-                  const SizedBox(height: 8),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Issues toolbar (sort + label filter)
+// ---------------------------------------------------------------------------
+
+class _IssuesToolbar extends StatelessWidget {
+  final IssueSort sort;
+  final List<String> allLabels;
+  final String? activeLabel;
+  final ValueChanged<IssueSort> onSortChanged;
+  final ValueChanged<String?> onLabelChanged;
+
+  const _IssuesToolbar({
+    required this.sort,
+    required this.allLabels,
+    required this.activeLabel,
+    required this.onSortChanged,
+    required this.onLabelChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.stoneDark,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Sort row
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+            child: Row(
+              children: [
+                Text(
+                  'Sort:',
+                  style: TextStyle(
+                      color: AppColors.textLight.withValues(alpha: 0.6),
+                      fontSize: 12),
+                ),
+                const SizedBox(width: 8),
+                _SortChip(
+                  label: '# Number',
+                  selected: sort == IssueSort.byNumber,
+                  onTap: () => onSortChanged(IssueSort.byNumber),
+                ),
+                const SizedBox(width: 6),
+                _SortChip(
+                  label: '🕐 Activity',
+                  selected: sort == IssueSort.byActivity,
+                  onTap: () => onSortChanged(IssueSort.byActivity),
+                ),
+              ],
+            ),
+          ),
+          // Label filter row (only if labels exist)
+          if (allLabels.isNotEmpty)
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+              child: Row(
+                children: [
+                  _FilterChip(
+                    label: 'All',
+                    selected: activeLabel == null,
+                    onTap: () => onLabelChanged(null),
+                  ),
+                  ...allLabels.map((l) => Padding(
+                        padding: const EdgeInsets.only(left: 6),
+                        child: _FilterChip(
+                          label: l,
+                          selected: activeLabel == l,
+                          onTap: () => onLabelChanged(activeLabel == l ? null : l),
+                        ),
+                      )),
+                ],
+              ),
+            ),
+          const Divider(color: AppColors.stoneMid, height: 1),
+        ],
+      ),
+    );
+  }
+}
+
+class _SortChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _SortChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.torchAmber : AppColors.stone,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: selected ? AppColors.torchAmber : AppColors.stoneMid,
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: selected ? AppColors.textDark : AppColors.textLight,
+            fontSize: 11,
+            fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FilterChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _FilterChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 3),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.stoneMid : Colors.transparent,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+            color: selected ? AppColors.torchAmber : AppColors.stoneMid,
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: selected ? AppColors.torchAmber : AppColors.textLight.withValues(alpha: 0.6),
+            fontSize: 11,
+            fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Issue list tile
+// ---------------------------------------------------------------------------
+
+class _IssueListTile extends StatelessWidget {
+  final IssueItem issue;
+  final bool hasPr;
+  final VoidCallback onTap;
+
+  const _IssueListTile({
+    required this.issue,
+    required this.hasPr,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Issue number badge
+            CircleAvatar(
+              backgroundColor: AppColors.stone,
+              radius: 16,
+              child: Text(
+                '#${issue.number}',
+                style: const TextStyle(
+                    color: AppColors.torchAmber,
+                    fontSize: 10,
+                    fontWeight: FontWeight.bold),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
                   Text(
-                    'No open alpha-feedback issues found, or unable to reach GitHub.',
-                    textAlign: TextAlign.center,
-                    style: tt.bodySmall?.copyWith(
-                        color: AppColors.textLight.withValues(alpha: 0.35)),
+                    issue.title,
+                    style: const TextStyle(
+                        color: AppColors.textLight, fontSize: 13),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 4,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      // Label chips
+                      ...issue.labelNames.map((l) => _LabelBadge(label: l)),
+                      // PR indicator
+                      if (hasPr)
+                        const _LabelBadge(
+                          label: '🔗 PR open',
+                          color: AppColors.torchGold,
+                          textColor: AppColors.textDark,
+                        ),
+                    ],
                   ),
                 ],
               ),
             ),
-          );
-        }
-        return ListView.separated(
-          padding: const EdgeInsets.all(16),
-          itemCount: issues.length,
-          separatorBuilder: (_, __) => const Divider(
-              color: AppColors.stoneMid, height: 1, indent: 56),
-          itemBuilder: (context, i) {
-            final issue = issues[i];
-            return ListTile(
-              leading: CircleAvatar(
-                backgroundColor: AppColors.stone,
-                radius: 16,
-                child: Text(
-                  '#${issue.number}',
-                  style: const TextStyle(
-                      color: AppColors.torchAmber,
-                      fontSize: 10,
-                      fontWeight: FontWeight.bold),
-                ),
-              ),
-              title: Text(
-                issue.title,
-                style: const TextStyle(
-                    color: AppColors.textLight, fontSize: 13),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-              subtitle: issue.labelNames.isNotEmpty
-                  ? Text(
-                      issue.labelNames.join(' · '),
-                      style: TextStyle(
-                          color: AppColors.textLight.withValues(alpha: 0.45),
-                          fontSize: 11),
-                    )
-                  : null,
-              trailing: const Icon(Icons.chevron_right,
-                  color: AppColors.stoneMid, size: 18),
-              contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-              onTap: () => _openDetail(issue),
-            );
-          },
-        );
-      },
+            const SizedBox(width: 8),
+            // Comment count + chevron
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (issue.commentCount > 0)
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.comment_outlined,
+                          size: 12,
+                          color: AppColors.textLight.withValues(alpha: 0.45)),
+                      const SizedBox(width: 3),
+                      Text(
+                        '${issue.commentCount}',
+                        style: TextStyle(
+                            color: AppColors.textLight.withValues(alpha: 0.45),
+                            fontSize: 11),
+                      ),
+                    ],
+                  ),
+                const SizedBox(height: 4),
+                const Icon(Icons.chevron_right,
+                    color: AppColors.stoneMid, size: 18),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LabelBadge extends StatelessWidget {
+  final String label;
+  final Color color;
+  final Color textColor;
+
+  const _LabelBadge({
+    required this.label,
+    this.color = AppColors.stone,
+    this.textColor = AppColors.textLight,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: AppColors.stoneMid.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(color: textColor, fontSize: 10),
+      ),
     );
   }
 }
@@ -997,9 +1332,9 @@ class _IssuesTabState extends State<_IssuesTab>
 
 class _IssueDetailSheet extends StatefulWidget {
   final IssueItem issue;
-  final String? userId;
+  final UserProfile? profile;
 
-  const _IssueDetailSheet({required this.issue, this.userId});
+  const _IssueDetailSheet({required this.issue, this.profile});
 
   @override
   State<_IssueDetailSheet> createState() => _IssueDetailSheetState();
@@ -1027,10 +1362,12 @@ class _IssueDetailSheetState extends State<_IssueDetailSheet> {
   Future<void> _submitComment() async {
     if (_commentCtrl.text.trim().isEmpty) return;
     setState(() => _submitting = true);
+    final profile = widget.profile;
     final ok = await GithubIssueService.addComment(
       issueNumber: widget.issue.number,
       body: _commentCtrl.text.trim(),
-      userId: widget.userId,
+      attribution: profile?.hasDisplayName == true ? profile!.attribution : null,
+      userId: profile?.userId,
     );
     if (!mounted) return;
     setState(() => _submitting = false);
@@ -1052,6 +1389,49 @@ class _IssueDetailSheetState extends State<_IssueDetailSheet> {
       );
     }
   }
+
+  MarkdownStyleSheet get _mdStyle => MarkdownStyleSheet(
+        p: TextStyle(
+            color: AppColors.textLight.withValues(alpha: 0.85),
+            fontSize: 13,
+            height: 1.5),
+        h1: const TextStyle(
+            color: AppColors.parchment,
+            fontSize: 16,
+            fontWeight: FontWeight.bold),
+        h2: const TextStyle(
+            color: AppColors.parchment,
+            fontSize: 14,
+            fontWeight: FontWeight.bold),
+        h3: TextStyle(
+            color: AppColors.parchment.withValues(alpha: 0.9),
+            fontSize: 13,
+            fontWeight: FontWeight.bold),
+        strong: const TextStyle(
+            color: AppColors.parchment, fontWeight: FontWeight.bold),
+        em: TextStyle(
+            color: AppColors.textLight.withValues(alpha: 0.85),
+            fontStyle: FontStyle.italic),
+        code: const TextStyle(
+            color: AppColors.torchAmber,
+            backgroundColor: AppColors.stoneDark,
+            fontSize: 12),
+        codeblockDecoration: BoxDecoration(
+            color: AppColors.stoneDark,
+            borderRadius: BorderRadius.circular(4)),
+        blockquoteDecoration: const BoxDecoration(
+            border: Border(
+                left: BorderSide(
+                    color: AppColors.stoneMid, width: 3))),
+        blockquotePadding:
+            const EdgeInsets.only(left: 12, top: 4, bottom: 4),
+        listBullet: TextStyle(
+            color: AppColors.textLight.withValues(alpha: 0.7)),
+        horizontalRuleDecoration: BoxDecoration(
+            border: Border(
+                top: BorderSide(
+                    color: AppColors.stoneMid.withValues(alpha: 0.5)))),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -1129,11 +1509,10 @@ class _IssueDetailSheetState extends State<_IssueDetailSheet> {
               padding: const EdgeInsets.all(20),
               children: [
                 if (widget.issue.body.isNotEmpty) ...[
-                  Text(
-                    widget.issue.body,
-                    style: tt.bodyMedium?.copyWith(
-                        color: AppColors.textLight.withValues(alpha: 0.85),
-                        height: 1.5),
+                  MarkdownBody(
+                    data: widget.issue.body,
+                    styleSheet: _mdStyle,
+                    shrinkWrap: true,
                   ),
                   const SizedBox(height: 20),
                   const Divider(color: AppColors.stoneMid),
@@ -1158,13 +1537,12 @@ class _IssueDetailSheetState extends State<_IssueDetailSheet> {
                       return Text(
                         'No comments yet.',
                         style: tt.bodySmall?.copyWith(
-                            color:
-                                AppColors.textLight.withValues(alpha: 0.4)),
+                            color: AppColors.textLight.withValues(alpha: 0.4)),
                       );
                     }
                     return Column(
                       children: comments
-                          .map((c) => _CommentCard(comment: c))
+                          .map((c) => _CommentCard(comment: c, mdStyle: _mdStyle))
                           .toList(),
                     );
                   },
@@ -1268,7 +1646,8 @@ class _IssueDetailSheetState extends State<_IssueDetailSheet> {
 
 class _CommentCard extends StatelessWidget {
   final IssueComment comment;
-  const _CommentCard({required this.comment});
+  final MarkdownStyleSheet mdStyle;
+  const _CommentCard({required this.comment, required this.mdStyle});
 
   @override
   Widget build(BuildContext context) {
@@ -1301,11 +1680,10 @@ class _CommentCard extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 6),
-          Text(
-            comment.body,
-            style: tt.bodySmall?.copyWith(
-                color: AppColors.textLight.withValues(alpha: 0.8),
-                height: 1.4),
+          MarkdownBody(
+            data: comment.body,
+            styleSheet: mdStyle,
+            shrinkWrap: true,
           ),
         ],
       ),

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Features
-- (none)
+- Issues tab — Markdown rendering for issue body and comments, pull-to-refresh, label filter chips, sort by issue number or latest activity, comment count badge, and PR-linked indicator per issue row; added comment now signs with display name when set (#82)
 
 ### Fixes
 - (none)


### PR DESCRIPTION
Closes #82

Implements all seven improvements to the in-app Issues tab:

- **Markdown rendering** — issue body and all comments now render via `flutter_markdown` (already in pubspec) instead of displaying raw text
- **Pull-to-refresh** — `RefreshIndicator` wraps the list; pulling down or triggering a sort change re-fetches from GitHub
- **Label filter chips** — a scrollable chip row above the list shows all labels present in the fetched issues; tapping a chip filters client-side; "All" clears the filter
- **Sort control** — toggle between `# Number` (default, `sort=created desc`) and `🕐 Activity` (`sort=updated desc`)
- **Comment count badge** — each list row shows a comment icon + count when `comments > 0` (parsed from the GitHub API response)
- **PR-linked indicator** — a `🔗 PR open` badge appears on issues whose number is referenced in the title/body of any open PR (fetched via `/pulls?state=open`)
- **Only open issues** — pre-existing; the `/issues?state=open` filter also now explicitly excludes items that are PRs themselves (GitHub returns PRs via the issues endpoint)
- **Display name in comments** — `addComment` now appends `**Submitted by:** <attribution>` when the user has a display name set, falling back to `**User ID:** \`id\`` only when the name is empty

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes (3 pre-existing failures unrelated to this branch)
- [ ] Manual: open Feedback → Issues tab; verify Markdown renders in issue detail
- [ ] Manual: pull down on the issues list; verify it re-fetches
- [ ] Manual: tap a label chip; verify the list filters; tap "All" to clear
- [ ] Manual: tap `🕐 Activity`; verify order changes; tap `# Number` to revert
- [ ] Manual: issues with comments show a comment count badge

🤖 Generated with [Claude Code](https://claude.ai/code)