### PR TITLE
fix: bug fix sprint — answer wrapping, game stats & permissions (#54 #83 #63)

### DIFF
--- a/lib/features/gameplay/presentation/screens/gameplay_screen.dart
+++ b/lib/features/gameplay/presentation/screens/gameplay_screen.dart
@@ -251,31 +251,42 @@ class _AnswerGrid extends StatelessWidget {
 
   static const _labels = ['A', 'B', 'C', 'D'];
 
+  AnswerState _stateFor(int i) {
+    if (selectedIndex == null) return AnswerState.idle;
+    if (i == question.correctIndex) return AnswerState.correct;
+    if (i == selectedIndex) return AnswerState.wrong;
+    return AnswerState.idle;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return GridView.count(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      crossAxisCount: 2,
-      mainAxisSpacing: 10,
-      crossAxisSpacing: 10,
-      childAspectRatio: 2.2,
-      children: List.generate(question.options.length, (i) {
-        AnswerState state = AnswerState.idle;
-        if (selectedIndex != null) {
-          if (i == question.correctIndex) {
-            state = AnswerState.correct;
-          } else if (i == selectedIndex && i != question.correctIndex) {
-            state = AnswerState.wrong;
-          }
-        }
-        return AnswerButton(
+    final buttons = List.generate(question.options.length, (i) {
+      return Expanded(
+        child: AnswerButton(
           label: _labels[i],
           text: question.options[i],
-          state: state,
+          state: _stateFor(i),
           onTap: () => onAnswer(i),
-        );
-      }),
+        ),
+      );
+    });
+
+    return Column(
+      children: [
+        IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [buttons[0], const SizedBox(width: 10), buttons[1]],
+          ),
+        ),
+        const SizedBox(height: 10),
+        IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [buttons[2], const SizedBox(width: 10), buttons[3]],
+          ),
+        ),
+      ],
     ).animate().fadeIn(duration: 300.ms, delay: 150.ms);
   }
 }

--- a/lib/features/results/presentation/screens/results_screen.dart
+++ b/lib/features/results/presentation/screens/results_screen.dart
@@ -40,8 +40,9 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
       score: gs.score,
       correct: gs.correctCount,
       answered: gs.questionsAnswered,
-      articlesFound: gs.newArticleUrls.length,
+      articlesFound: gs.seenArticleUrls.length,
       won: gs.status == GameStatus.complete,
+      isEndless: isEndless,
       endlessScore: isEndless ? gs.score : null,
     );
     if (mounted) setState(() => _savedStats = saved);

--- a/lib/features/settings/data/game_stats_repository.dart
+++ b/lib/features/settings/data/game_stats_repository.dart
@@ -27,6 +27,7 @@ class GameStatsRepository {
     required int answered,
     required int articlesFound,
     required bool won,
+    required bool isEndless,
     int? endlessScore,
   }) async {
     final current = await load();
@@ -36,6 +37,7 @@ class GameStatsRepository {
       answered: answered,
       articlesFound: articlesFound,
       won: won,
+      isEndless: isEndless,
       endlessScore: endlessScore,
     );
     await save(updated);

--- a/lib/features/settings/domain/models/game_stats.dart
+++ b/lib/features/settings/domain/models/game_stats.dart
@@ -1,5 +1,6 @@
 class GameStats {
   final int gamesPlayed;
+  final int standardGamesPlayed;
   final int totalWins;
   final int bestScore;
   final int totalScore;
@@ -10,6 +11,7 @@ class GameStats {
 
   const GameStats({
     this.gamesPlayed = 0,
+    this.standardGamesPlayed = 0,
     this.totalWins = 0,
     this.bestScore = 0,
     this.totalScore = 0,
@@ -22,8 +24,11 @@ class GameStats {
   double get accuracy =>
       totalAnswered == 0 ? 0.0 : totalCorrect / totalAnswered;
 
+  /// Win rate is scoped to Standard mode games only.
+  /// Endless games are excluded because they end via lives-out (gameOver),
+  /// not via completing the question set, so they never produce a "win".
   double get winRate =>
-      gamesPlayed == 0 ? 0.0 : totalWins / gamesPlayed;
+      standardGamesPlayed == 0 ? 0.0 : totalWins / standardGamesPlayed;
 
   GameStats recordGame({
     required int score,
@@ -31,10 +36,13 @@ class GameStats {
     required int answered,
     required int articlesFound,
     required bool won,
+    required bool isEndless,
     int? endlessScore,
   }) {
     return GameStats(
       gamesPlayed: gamesPlayed + 1,
+      standardGamesPlayed:
+          isEndless ? standardGamesPlayed : standardGamesPlayed + 1,
       totalWins: won ? totalWins + 1 : totalWins,
       bestScore: score > bestScore ? score : bestScore,
       totalScore: totalScore + score,
@@ -49,6 +57,7 @@ class GameStats {
 
   Map<String, dynamic> toJson() => {
         'gamesPlayed': gamesPlayed,
+        'standardGamesPlayed': standardGamesPlayed,
         'totalWins': totalWins,
         'bestScore': bestScore,
         'totalScore': totalScore,
@@ -60,6 +69,11 @@ class GameStats {
 
   factory GameStats.fromJson(Map<String, dynamic> json) => GameStats(
         gamesPlayed: (json['gamesPlayed'] as int?) ?? 0,
+        // Existing saved data won't have this field — default to gamesPlayed
+        // so returning users keep their historical win rate rather than seeing 0%.
+        standardGamesPlayed: (json['standardGamesPlayed'] as int?) ??
+            (json['gamesPlayed'] as int?) ??
+            0,
         totalWins: (json['totalWins'] as int?) ?? 0,
         bestScore: (json['bestScore'] as int?) ?? 0,
         totalScore: (json['totalScore'] as int?) ?? 0,

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -395,7 +395,7 @@ class _StatsGrid extends StatelessWidget {
         const SizedBox(height: 12),
         Row(
           children: [
-            _StatCell(label: 'Win Rate',  value: '$winPct%'),
+            _StatCell(label: 'Win Rate (Std)',  value: '$winPct%'),
             _StatCell(label: 'Accuracy',  value: '$accuracyPct%'),
           ],
         ),

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,8 @@
 - (none)
 
 ### Fixes
-- (none)
+- Articles opened now counts all unique articles visited during the session, not just notebook-new ones (#83)
+- Win rate on the stats screen is now scoped to Standard mode games only and labelled "Win Rate (Std)" — Endless games no longer dilute it (#83)
 
 ### Content
 - (none)

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,7 @@
 - (none)
 
 ### Fixes
+- Answer option text now wraps correctly instead of being clipped on long options (#54)
 - Articles opened now counts all unique articles visited during the session, not just notebook-new ones (#83)
 - Win rate on the stats screen is now scoped to Standard mode games only and labelled "Win Rate (Std)" — Endless games no longer dilute it (#83)
 

--- a/test/features/gameplay/presentation/answer_grid_text_wrap_test.dart
+++ b/test/features/gameplay/presentation/answer_grid_text_wrap_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mind_maze/features/gameplay/presentation/widgets/answer_button.dart';
+
+void main() {
+  group('AnswerButton — long text wrapping', () {
+    Widget buildButton(String text) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: AnswerButton(
+              label: 'A',
+              text: text,
+              state: AnswerState.idle,
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('short text renders without overflow', (tester) async {
+      await tester.pumpWidget(buildButton('Short answer'));
+      expect(tester.takeException(), isNull);
+      expect(find.text('Short answer'), findsOneWidget);
+    });
+
+    testWidgets('long text renders fully without overflow', (tester) async {
+      const longText =
+          'A very long answer option that spans more than one line of text '
+          'and should wrap rather than be clipped or cause a render overflow';
+      await tester.pumpWidget(buildButton(longText));
+      // No RenderFlex overflow exception
+      expect(tester.takeException(), isNull);
+      expect(find.text(longText), findsOneWidget);
+    });
+  });
+}

--- a/test/features/settings/domain/game_stats_test.dart
+++ b/test/features/settings/domain/game_stats_test.dart
@@ -6,6 +6,7 @@ void main() {
     test('defaults are all zero', () {
       const s = GameStats();
       expect(s.gamesPlayed, 0);
+      expect(s.standardGamesPlayed, 0);
       expect(s.totalWins, 0);
       expect(s.bestScore, 0);
       expect(s.totalScore, 0);
@@ -25,44 +26,52 @@ void main() {
     group('recordGame', () {
       test('increments gamesPlayed', () {
         final s = const GameStats().recordGame(
-          score: 10, correct: 1, answered: 2, articlesFound: 0, won: false,
+          score: 10, correct: 1, answered: 2, articlesFound: 0,
+          won: false, isEndless: false,
         );
         expect(s.gamesPlayed, 1);
       });
 
       test('updates bestScore only when higher', () {
         var s = const GameStats().recordGame(
-          score: 50, correct: 5, answered: 5, articlesFound: 0, won: true,
+          score: 50, correct: 5, answered: 5, articlesFound: 0,
+          won: true, isEndless: false,
         );
         s = s.recordGame(
-          score: 30, correct: 3, answered: 5, articlesFound: 0, won: true,
+          score: 30, correct: 3, answered: 5, articlesFound: 0,
+          won: true, isEndless: false,
         );
         expect(s.bestScore, 50);
 
         s = s.recordGame(
-          score: 80, correct: 8, answered: 10, articlesFound: 2, won: true,
+          score: 80, correct: 8, answered: 10, articlesFound: 2,
+          won: true, isEndless: false,
         );
         expect(s.bestScore, 80);
       });
 
       test('totalWins increments only on won=true', () {
         var s = const GameStats().recordGame(
-          score: 0, correct: 0, answered: 5, articlesFound: 0, won: false,
+          score: 0, correct: 0, answered: 5, articlesFound: 0,
+          won: false, isEndless: false,
         );
         expect(s.totalWins, 0);
 
         s = s.recordGame(
-          score: 50, correct: 5, answered: 5, articlesFound: 0, won: true,
+          score: 50, correct: 5, answered: 5, articlesFound: 0,
+          won: true, isEndless: false,
         );
         expect(s.totalWins, 1);
       });
 
       test('accumulates totalScore, totalCorrect, totalAnswered, totalArticlesFound', () {
         var s = const GameStats().recordGame(
-          score: 40, correct: 4, answered: 5, articlesFound: 2, won: true,
+          score: 40, correct: 4, answered: 5, articlesFound: 2,
+          won: true, isEndless: false,
         );
         s = s.recordGame(
-          score: 60, correct: 6, answered: 10, articlesFound: 3, won: true,
+          score: 60, correct: 6, answered: 10, articlesFound: 3,
+          won: true, isEndless: false,
         );
         expect(s.totalScore, 100);
         expect(s.totalCorrect, 10);
@@ -72,19 +81,43 @@ void main() {
 
       test('accuracy computes correctly', () {
         final s = const GameStats().recordGame(
-          score: 80, correct: 8, answered: 10, articlesFound: 0, won: true,
+          score: 80, correct: 8, answered: 10, articlesFound: 0,
+          won: true, isEndless: false,
         );
         expect(s.accuracy, closeTo(0.8, 0.0001));
       });
 
-      test('winRate computes correctly', () {
+      test('winRate is scoped to Standard games only', () {
+        // 1 Standard win
         var s = const GameStats().recordGame(
-          score: 50, correct: 5, answered: 5, articlesFound: 0, won: true,
+          score: 50, correct: 5, answered: 5, articlesFound: 0,
+          won: true, isEndless: false,
         );
+        // 1 Standard loss
         s = s.recordGame(
-          score: 0, correct: 0, answered: 5, articlesFound: 0, won: false,
+          score: 0, correct: 0, answered: 5, articlesFound: 0,
+          won: false, isEndless: false,
         );
+        // Endless game (ends in gameOver — not a win)
+        s = s.recordGame(
+          score: 120, correct: 12, answered: 15, articlesFound: 1,
+          won: false, isEndless: true, endlessScore: 120,
+        );
+        // winRate = 1 Standard win / 2 Standard games = 0.5
+        // Endless game does NOT dilute the win rate
+        expect(s.standardGamesPlayed, 2);
+        expect(s.gamesPlayed, 3);
         expect(s.winRate, closeTo(0.5, 0.0001));
+      });
+
+      test('Endless game does not increment standardGamesPlayed', () {
+        final s = const GameStats().recordGame(
+          score: 200, correct: 20, answered: 25, articlesFound: 3,
+          won: false, isEndless: true, endlessScore: 200,
+        );
+        expect(s.gamesPlayed, 1);
+        expect(s.standardGamesPlayed, 0);
+        expect(s.winRate, 0.0);
       });
     });
 
@@ -92,6 +125,7 @@ void main() {
       test('round-trips through toJson/fromJson', () {
         const original = GameStats(
           gamesPlayed: 5,
+          standardGamesPlayed: 3,
           totalWins: 3,
           bestScore: 90,
           totalScore: 350,
@@ -101,6 +135,7 @@ void main() {
         );
         final restored = GameStats.fromJson(original.toJson());
         expect(restored.gamesPlayed, original.gamesPlayed);
+        expect(restored.standardGamesPlayed, original.standardGamesPlayed);
         expect(restored.totalWins, original.totalWins);
         expect(restored.bestScore, original.bestScore);
         expect(restored.totalScore, original.totalScore);
@@ -113,6 +148,13 @@ void main() {
         final s = GameStats.fromJson({});
         expect(s.gamesPlayed, 0);
         expect(s.bestScore, 0);
+        expect(s.standardGamesPlayed, 0);
+      });
+
+      test('fromJson defaults standardGamesPlayed to gamesPlayed for saved data without the field', () {
+        // Simulate pre-fix saved data: has gamesPlayed but no standardGamesPlayed
+        final s = GameStats.fromJson({'gamesPlayed': 7, 'totalWins': 3});
+        expect(s.standardGamesPlayed, 7);
       });
     });
   });


### PR DESCRIPTION
Closes #54
Closes #83

> Also includes #63 (permissions) via branch `improvement/issue-63-app-permissions` which targets main separately.

---

## Changes

### #54 — Answer button text wraps instead of clipping
**Root cause:** `_AnswerGrid` used `GridView.count` with `childAspectRatio: 2.2`, fixing cells to a rigid height. Long answer text was clipped.

**Fix:** Replaced with a `Column` of two `IntrinsicHeight` rows. Cells now grow to fit content.

### #83 — Game stats accurate
**Bug 1 — Articles Found = 0 for returning users:** `results_screen.dart` passed `gs.newArticleUrls.length` — only URLs new to the notebook. Fixed to `gs.seenArticleUrls.length` (all unique URLs opened this session).

**Bug 2 — Win Rate diluted by Endless games:** `winRate` divided Standard wins by total games played. Added `standardGamesPlayed` field; win rate now uses it as denominator. Backward-compatible: existing saved data defaults `standardGamesPlayed` to `gamesPlayed`. UI label updated to "Win Rate (Std)".

---

## Test plan
- [x] `flutter analyze --fatal-infos` passes
- [x] `flutter test` passes (84 tests, 0 failures)
- [ ] Manual: Play a game, open 1–2 articles → stats screen shows correct article count
- [ ] Manual: Win a Standard game → "Win Rate (Std)" increases; Endless game-over does not affect it
- [ ] Manual: Answer a question with a long option — text wraps, no clipping