### PR TITLE
improvement: app permissions audit and VIBRATE fix (#63)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Required for WebView (article viewer), HTTP update downloads, and GitHub API calls. -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <!-- Required to launch the package installer after downloading an APK update via open_filex. -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
+    <!-- Required for HapticFeedback.mediumImpact() used on answer selection in gameplay. -->
+    <uses-permission android:name="android.permission.VIBRATE"/>
     <application
         android:label="Mind Mazeish"
         android:name="${applicationName}"

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,7 @@
 - (none)
 
 ### Fixes
-- (none)
+- Added missing VIBRATE permission to AndroidManifest for haptic feedback on answer selection; documented purpose of all declared permissions (#63)
 
 ### Content
 - (none)


### PR DESCRIPTION
Closes #63

**Audit results:**

| Permission | Status | Used by |
|---|---|---|
| `INTERNET` | ✅ already declared | WebView, HTTP update downloads, GitHub API |
| `REQUEST_INSTALL_PACKAGES` | ✅ already declared | `open_filex` APK installer |
| `VIBRATE` | ⚠️ **missing — added** | `HapticFeedback.mediumImpact()` on answer selection |

No over-declared permissions found. No dangerous runtime permissions are needed — all permissions used are "normal" (auto-granted) or system-managed appop (`REQUEST_INSTALL_PACKAGES`).

**Change:** Added `android.permission.VIBRATE` and added inline comments to each `<uses-permission>` entry explaining its purpose.

## Test plan
- [x] `flutter analyze --fatal-infos` passes
- [x] `flutter test` passes (80 tests, 0 failures)
- [ ] Manual: Play a game and answer a question — haptic feedback fires without any permission errors in logcat