### PR TITLE
feat: Release B — v1.2 Gameplay UX (#55 #56 #62)

### DIFF
--- a/lib/features/gameplay/presentation/screens/gameplay_screen.dart
+++ b/lib/features/gameplay/presentation/screens/gameplay_screen.dart
@@ -57,7 +57,17 @@ class _GameplayScreenState extends ConsumerState<GameplayScreen> {
     final streakLimit =
         ref.read(gameStateProvider)?.config.streakLimit ?? 10;
 
-    if (mounted) await _showFunFact(question.funFact, correct, reward: reward, streakLimit: streakLimit);
+    if (mounted) {
+      await _showFunFact(
+        question.funFact,
+        correct,
+        articleUrl: question.articleUrl,
+        articleTitle: question.articleTitle,
+        topicId: question.topicId,
+        reward: reward,
+        streakLimit: streakLimit,
+      );
+    }
 
     final gs = ref.read(gameStateProvider);
     if (gs == null) return;
@@ -80,10 +90,16 @@ class _GameplayScreenState extends ConsumerState<GameplayScreen> {
   Future<void> _showFunFact(
     String funFact,
     bool correct, {
+    String articleUrl = '',
+    String articleTitle = '',
+    String topicId = '',
     StreakReward? reward,
     int streakLimit = 10,
   }) async {
     if (!mounted) return;
+
+    bool openArticle = false;
+
     await showModalBottomSheet<void>(
       context: context,
       backgroundColor: AppColors.stoneDark,
@@ -96,8 +112,24 @@ class _GameplayScreenState extends ConsumerState<GameplayScreen> {
         correct: correct,
         reward: reward,
         streakLimit: streakLimit,
+        articleUrl: articleUrl,
+        articleTitle: articleTitle,
+        onArticleTap: articleUrl.isNotEmpty
+            ? () {
+                openArticle = true;
+                Navigator.of(ctx).pop();
+              }
+            : null,
       ),
     );
+
+    if (openArticle && mounted) {
+      await context.push<void>('/article', extra: {
+        'url': articleUrl,
+        'title': articleTitle,
+        'topicId': topicId,
+      });
+    }
   }
 
   @override
@@ -154,44 +186,49 @@ class _GameplayScreenState extends ConsumerState<GameplayScreen> {
           streak: gs.streak,
           isEndless: gs.config.gameMode == GameMode.endless,
         ),
-        body: Column(
-          children: [
-            _TopicIllustration(topicId: question.topicId),
-            Expanded(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-                child: Column(
-                  children: [
-                    if (gs.status == GameStatus.loading)
-                      const QuestionCardSkeleton()
-                    else ...[
-                      QuestionCard(
-                        question: question,
-                        onArticleTap: question.articleUrl.isEmpty
-                            ? null
-                            : () => context.push('/article', extra: {
-                                  'url': question.articleUrl,
-                                  'title': question.articleTitle,
-                                  'topicId': question.topicId,
-                                }),
-                      ),
-                      const SizedBox(height: 14),
-                      _AnswerGrid(
-                        question: question,
-                        selectedIndex: _selectedIndex,
-                        onAnswer: (i) => _handleAnswer(i, question),
-                      ),
-                    ],
-                    const SizedBox(height: 16),
-                    _ProgressBar(
-                      current: gs.currentQuestionIndex + 1,
-                      total: gs.questions.length,
+        body: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 520),
+            child: Column(
+              children: [
+                _TopicIllustration(topicId: question.topicId),
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                    child: Column(
+                      children: [
+                        if (gs.status == GameStatus.loading)
+                          const QuestionCardSkeleton()
+                        else ...[
+                          QuestionCard(
+                            question: question,
+                            onArticleTap: question.articleUrl.isEmpty
+                                ? null
+                                : () => context.push('/article', extra: {
+                                      'url': question.articleUrl,
+                                      'title': question.articleTitle,
+                                      'topicId': question.topicId,
+                                    }),
+                          ),
+                          const SizedBox(height: 14),
+                          _AnswerGrid(
+                            question: question,
+                            selectedIndex: _selectedIndex,
+                            onAnswer: (i) => _handleAnswer(i, question),
+                          ),
+                        ],
+                        const SizedBox(height: 16),
+                        _ProgressBar(
+                          current: gs.currentQuestionIndex + 1,
+                          total: gs.questions.length,
+                        ),
+                      ],
                     ),
-                  ],
+                  ),
                 ),
-              ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );
@@ -209,8 +246,10 @@ class _TopicIllustration extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    final illustrationHeight = (screenHeight * 0.20).clamp(100.0, 160.0);
     return Container(
-      height: MediaQuery.of(context).size.height * 0.22,
+      height: illustrationHeight,
       width: double.infinity,
       color: AppColors.stoneDark,
       child: Stack(
@@ -342,12 +381,18 @@ class _FunFactSheet extends StatelessWidget {
   final bool correct;
   final StreakReward? reward;
   final int streakLimit;
+  final String articleUrl;
+  final String articleTitle;
+  final VoidCallback? onArticleTap;
 
   const _FunFactSheet({
     required this.funFact,
     required this.correct,
     this.reward,
     this.streakLimit = 10,
+    this.articleUrl = '',
+    this.articleTitle = '',
+    this.onArticleTap,
   });
 
   @override
@@ -428,7 +473,30 @@ class _FunFactSheet extends StatelessWidget {
                   style: textTheme.labelMedium
                       ?.copyWith(color: AppColors.textLight, height: 1.5)),
             ),
-            const SizedBox(height: 18),
+            const SizedBox(height: 14),
+            if (onArticleTap != null) ...[
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: onArticleTap,
+                  icon: const Icon(Icons.menu_book,
+                      size: 16, color: AppColors.torchAmber),
+                  label: Text(
+                    articleTitle.isNotEmpty ? articleTitle : 'Read Article',
+                    style: textTheme.labelMedium?.copyWith(
+                        color: AppColors.torchAmber),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: AppColors.torchAmber,
+                    side: const BorderSide(
+                        color: AppColors.torchAmber, width: 1),
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+            ],
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(

--- a/lib/features/results/presentation/screens/results_screen.dart
+++ b/lib/features/results/presentation/screens/results_screen.dart
@@ -89,7 +89,10 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
             ),
           ),
           SafeArea(
-            child: SingleChildScrollView(
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 520),
+                child: SingleChildScrollView(
               padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 24),
               child: Column(
                 children: [
@@ -223,6 +226,8 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
                       .slideY(begin: 0.2, end: 0, duration: 400.ms),
                   const SizedBox(height: 16),
                 ],
+              ),
+            ),
               ),
             ),
           ),

--- a/lib/features/start/presentation/screens/question_stats_screen.dart
+++ b/lib/features/start/presentation/screens/question_stats_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/theme/app_theme.dart';
+import '../../../feedback/data/github_issue_service.dart';
 import '../../../gameplay/data/topic_registry.dart';
 
 // ---------------------------------------------------------------------------
@@ -42,7 +43,7 @@ final _statsProvider = FutureProvider<List<_TopicStats>>((ref) async {
     // --- questions ---
     int questionCount = 0;
     int questionsWithInlineUrl = 0;
-    final questionSourceIds = <String>{};
+    final questionSourceIdList = <String>[];
 
     try {
       final raw =
@@ -53,7 +54,7 @@ final _statsProvider = FutureProvider<List<_TopicStats>>((ref) async {
         final url = e['articleUrl'] as String? ?? '';
         if (url.isNotEmpty) questionsWithInlineUrl++;
         final sourceId = e['sourceId'] as String? ?? '';
-        if (sourceId.isNotEmpty) questionSourceIds.add(sourceId);
+        questionSourceIdList.add(sourceId);
       }
     } catch (_) {
       // No topic file yet — counts stay 0.
@@ -79,10 +80,15 @@ final _statsProvider = FutureProvider<List<_TopicStats>>((ref) async {
       // No sources file — count stays 0.
     }
 
-    // Questions with URL = inline URL OR sourceId pointing to a source with URL
-    final questionsWithSourceUrl = questionSourceIds
-        .where((id) => sourceUrlsBySourceId[id] == true)
-        .length;
+    // Questions with URL = inline URL OR sourceId pointing to a source with URL.
+    // Count per-question (not per unique sourceId) to avoid undercounting when
+    // multiple questions share the same sourceId.
+    int questionsWithSourceUrl = 0;
+    for (final sid in questionSourceIdList) {
+      if (sid.isNotEmpty && sourceUrlsBySourceId[sid] == true) {
+        questionsWithSourceUrl++;
+      }
+    }
     final questionsWithUrl = questionsWithInlineUrl + questionsWithSourceUrl;
 
     stats.add(_TopicStats(
@@ -320,62 +326,258 @@ class _TopicRow extends StatelessWidget {
       qColor = AppColors.torchGold;
     }
 
-    final missingUrls = stats.questionsWithoutUrl;
-    final urlColor = missingUrls == 0
+    final withUrl = stats.questionsWithUrl;
+    final urlLabel = withUrl == qCount ? '✓' : '$withUrl/$qCount';
+    final urlColor = withUrl == qCount
         ? AppColors.torchGold
-        : missingUrls < qCount
+        : withUrl > 0
             ? AppColors.torchAmber
             : AppColors.dangerRed;
 
-    return Container(
-      margin: const EdgeInsets.only(bottom: 4),
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-      decoration: BoxDecoration(
-        color: AppColors.stone.withValues(alpha: 0.3),
-        borderRadius: BorderRadius.circular(6),
-        border: Border.all(color: AppColors.stoneMid.withValues(alpha: 0.5)),
+    return InkWell(
+      onTap: () => _showContentRequestDialog(context),
+      borderRadius: BorderRadius.circular(6),
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: AppColors.stone.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: AppColors.stoneMid.withValues(alpha: 0.5)),
+        ),
+        child: Row(
+          children: [
+            Text(stats.topicEmoji, style: const TextStyle(fontSize: 16)),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                stats.topicName,
+                style: textTheme.bodySmall
+                    ?.copyWith(color: AppColors.textLight),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            SizedBox(
+              width: 52,
+              child: Text(
+                '$qCount',
+                textAlign: TextAlign.center,
+                style: textTheme.bodySmall?.copyWith(
+                    color: qColor, fontWeight: FontWeight.bold),
+              ),
+            ),
+            SizedBox(
+              width: 52,
+              child: Text(
+                '${stats.sourceCount}',
+                textAlign: TextAlign.center,
+                style: textTheme.bodySmall
+                    ?.copyWith(color: AppColors.textLight.withValues(alpha: 0.7)),
+              ),
+            ),
+            SizedBox(
+              width: 52,
+              child: Text(
+                urlLabel,
+                textAlign: TextAlign.center,
+                style: textTheme.bodySmall
+                    ?.copyWith(color: urlColor, fontWeight: FontWeight.bold),
+              ),
+            ),
+          ],
+        ),
       ),
-      child: Row(
-        children: [
-          Text(stats.topicEmoji, style: const TextStyle(fontSize: 16)),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              stats.topicName,
-              style: textTheme.bodySmall
-                  ?.copyWith(color: AppColors.textLight),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          SizedBox(
-            width: 52,
-            child: Text(
-              '$qCount',
-              textAlign: TextAlign.center,
-              style: textTheme.bodySmall?.copyWith(
-                  color: qColor, fontWeight: FontWeight.bold),
-            ),
-          ),
-          SizedBox(
-            width: 52,
-            child: Text(
-              '${stats.sourceCount}',
-              textAlign: TextAlign.center,
-              style: textTheme.bodySmall
-                  ?.copyWith(color: AppColors.textLight.withValues(alpha: 0.7)),
-            ),
-          ),
-          SizedBox(
-            width: 52,
-            child: Text(
-              missingUrls == 0 ? '✓' : '−$missingUrls',
-              textAlign: TextAlign.center,
-              style: textTheme.bodySmall
-                  ?.copyWith(color: urlColor, fontWeight: FontWeight.bold),
-            ),
-          ),
-        ],
+    );
+  }
+
+  void _showContentRequestDialog(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => _ContentRequestDialog(stats: stats),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Content request dialog
+// ---------------------------------------------------------------------------
+
+class _ContentRequestDialog extends StatefulWidget {
+  final _TopicStats stats;
+
+  const _ContentRequestDialog({required this.stats});
+
+  @override
+  State<_ContentRequestDialog> createState() => _ContentRequestDialogState();
+}
+
+class _ContentRequestDialogState extends State<_ContentRequestDialog> {
+  int _sourcesRequested = 1;
+  int _questionsRequested = 10;
+  bool _submitting = false;
+  bool _submitted = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return AlertDialog(
+      backgroundColor: AppColors.stoneDark,
+      title: Text(
+        'Request Content',
+        style: textTheme.displaySmall?.copyWith(
+            color: AppColors.torchAmber, fontSize: 18),
       ),
+      content: _submitted
+          ? Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.check_circle,
+                    color: AppColors.torchGold, size: 40),
+                const SizedBox(height: 12),
+                Text(
+                  'Request submitted for ${widget.stats.topicName}!',
+                  style: textTheme.labelMedium
+                      ?.copyWith(color: AppColors.textLight),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            )
+          : Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${widget.stats.topicEmoji} ${widget.stats.topicName}',
+                  style: textTheme.labelLarge
+                      ?.copyWith(color: AppColors.textLight),
+                ),
+                const SizedBox(height: 16),
+                _CounterRow(
+                  label: 'New sources',
+                  value: _sourcesRequested,
+                  min: 1,
+                  max: 20,
+                  onChanged: (v) => setState(() => _sourcesRequested = v),
+                ),
+                const SizedBox(height: 12),
+                _CounterRow(
+                  label: 'New questions',
+                  value: _questionsRequested,
+                  min: 5,
+                  max: 100,
+                  step: 5,
+                  onChanged: (v) => setState(() => _questionsRequested = v),
+                ),
+              ],
+            ),
+      actions: _submitted
+          ? [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Close',
+                    style: TextStyle(color: AppColors.torchAmber)),
+              ),
+            ]
+          : [
+              TextButton(
+                onPressed:
+                    _submitting ? null : () => Navigator.of(context).pop(),
+                child: const Text('Cancel',
+                    style: TextStyle(color: AppColors.torchAmber)),
+              ),
+              ElevatedButton(
+                onPressed: _submitting ? null : _submit,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.torchAmber,
+                  foregroundColor: AppColors.textDark,
+                ),
+                child: _submitting
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: AppColors.textDark),
+                      )
+                    : const Text('Submit'),
+              ),
+            ],
+    );
+  }
+
+  Future<void> _submit() async {
+    setState(() => _submitting = true);
+    await GithubIssueService.submitContentRequest(
+      type: ContentRequestType.moreQuestions,
+      title: 'More content for ${widget.stats.topicName}',
+      body: 'Please add more content for the **${widget.stats.topicName}** topic.\n\n'
+          '- Requested new sources: **$_sourcesRequested**\n'
+          '- Requested new questions: **$_questionsRequested**\n\n'
+          'Current stats: ${widget.stats.questionCount} questions, '
+          '${widget.stats.sourceCount} sources, '
+          '${widget.stats.questionsWithUrl}/${widget.stats.questionCount} with article URLs.',
+      topicId: widget.stats.topicId,
+    );
+    if (mounted) setState(() => _submitted = true);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Counter row widget
+// ---------------------------------------------------------------------------
+
+class _CounterRow extends StatelessWidget {
+  final String label;
+  final int value;
+  final int min;
+  final int max;
+  final int step;
+  final ValueChanged<int> onChanged;
+
+  const _CounterRow({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    this.step = 1,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Row(
+      children: [
+        Expanded(
+          child: Text(label,
+              style: textTheme.labelMedium
+                  ?.copyWith(color: AppColors.textLight)),
+        ),
+        IconButton(
+          onPressed: value > min ? () => onChanged(value - step) : null,
+          icon: const Icon(Icons.remove_circle_outline,
+              color: AppColors.torchAmber, size: 20),
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+        ),
+        SizedBox(
+          width: 36,
+          child: Text(
+            '$value',
+            textAlign: TextAlign.center,
+            style: textTheme.labelLarge?.copyWith(
+                color: AppColors.torchGold, fontWeight: FontWeight.bold),
+          ),
+        ),
+        IconButton(
+          onPressed: value < max ? () => onChanged(value + step) : null,
+          icon: const Icon(Icons.add_circle_outline,
+              color: AppColors.torchAmber, size: 20),
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/start/presentation/screens/start_screen.dart
+++ b/lib/features/start/presentation/screens/start_screen.dart
@@ -25,6 +25,11 @@ class StartScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final textTheme = Theme.of(context).textTheme;
     final size = MediaQuery.of(context).size;
+    // Scale title sizes relative to 393 dp (Pixel 9 reference width), clamped
+    // so small phones still look good and tablets don't get enormous text.
+    final scale = (size.width / 393).clamp(0.8, 1.3);
+    final titleSize = (52 * scale).roundToDouble();
+    final subtitleSize = (42 * scale).roundToDouble();
 
     return Scaffold(
       body: Stack(
@@ -32,13 +37,15 @@ class StartScreen extends ConsumerWidget {
           Positioned.fill(child: CustomPaint(painter: _StartBackgroundPainter())),
           SafeArea(
             child: Center(
-              child: Padding(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 520),
+                child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 32),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    const Icon(Icons.local_fire_department,
-                            size: 72, color: AppColors.torchAmber)
+                    Icon(Icons.local_fire_department,
+                            size: (72 * scale).clamp(56, 90), color: AppColors.torchAmber)
                         .animate(onPlay: (c) => c.repeat(reverse: true))
                         .custom(
                           duration: 1800.ms,
@@ -47,14 +54,14 @@ class StartScreen extends ConsumerWidget {
                         ),
                     const SizedBox(height: 24),
                     Text('MIND',
-                            style: textTheme.displayLarge?.copyWith(fontSize: 52),
+                            style: textTheme.displayLarge?.copyWith(fontSize: titleSize),
                             textAlign: TextAlign.center)
                         .animate()
                         .fadeIn(duration: 700.ms)
                         .slideY(begin: -0.2, end: 0, duration: 700.ms),
                     Text('MAZEISH',
                             style: textTheme.displayLarge?.copyWith(
-                                fontSize: 42,
+                                fontSize: subtitleSize,
                                 color: AppColors.torchGold,
                                 letterSpacing: 6),
                             textAlign: TextAlign.center)
@@ -146,6 +153,7 @@ class StartScreen extends ConsumerWidget {
               ),
             ),
           ),
+        ),
         ],
       ),
     );

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,10 +3,12 @@
 ## Unreleased
 
 ### Features
-- (none)
+- After answering a question, the fun-fact sheet now shows a **"Read Article"** button that opens the Wikipedia article in the in-app viewer before proceeding (#55)
+- Question bank rows are now tappable — tap any topic to open a **content-request form** and submit a request for more sources or questions (#56)
+- UI scales responsively across screen sizes: content is capped at 520 dp wide on tablets, the gameplay illustration height is clamped for small phones, and the start screen title adapts to screen width (#62)
 
 ### Fixes
-- (none)
+- Question bank URL column now shows `W/T` (questions-with-URL / total) instead of the confusing `−N` notation, and the count is calculated per-question rather than per-unique-sourceId so shared sources are counted correctly (#56)
 
 ### Content
 - (none)


### PR DESCRIPTION
Closes #55
Closes #56
Closes #62

## Summary

- **#55 — Wiki link in fun-fact sheet**: After answering a question, the bottom sheet now shows a "Read Article" button (when a Wikipedia URL exists). Tapping it closes the sheet, opens the in-app article viewer, then returns the player to the game flow.
- **#56 — Question bank readability**: Fixed a calculation bug where per-unique-sourceId counting undercounted covered questions. URL column now shows `W/T` (with-url / total) instead of the confusing `−N` notation. Each topic row is now tappable and opens a content-request dialog to submit new sources/questions via GitHub.
- **#62 — Responsive scaling**: All screens now cap content at 520 dp wide (tablet-friendly, centred). The gameplay topic illustration height is clamped (`max 160 dp`) so small phones aren't dominated by it. Start screen title font sizes scale with screen width (clamped 80%–130% of reference).

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes (84 tests)
- [ ] Manual — #55: answer a question, verify "Read Article" button appears in the fun-fact sheet; tap it, confirm the Wikipedia article opens; return to game and confirm the next question loads
- [ ] Manual — #56: open Question Bank from Settings; verify URL column shows `W/T` format; tap a row and confirm the content-request dialog opens with counter inputs and a Submit button
- [ ] Manual — #62: run on a small-screen device (Pixel 6 emulator) and a large tablet; confirm content is centred and nothing clips or overflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)