### PR TITLE
feat: Release C — v1.3 Onboarding & Settings (#59)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,7 @@ import 'features/results/presentation/screens/results_screen.dart';
 import 'features/notebook/presentation/screens/notebook_screen.dart';
 import 'features/feedback/presentation/screens/feedback_screen.dart';
 import 'features/start/presentation/screens/question_stats_screen.dart';
+import 'features/start/presentation/screens/how_to_play_screen.dart';
 import 'features/settings/presentation/screens/settings_screen.dart';
 
 final _router = GoRouter(
@@ -34,6 +35,7 @@ final _router = GoRouter(
     GoRoute(path: '/notebook', builder: (_, __) => const NotebookScreen()),
     GoRoute(path: '/feedback', builder: (_, __) => const FeedbackScreen()),
     GoRoute(path: '/stats', builder: (_, __) => const QuestionStatsScreen()),
+    GoRoute(path: '/how-to-play', builder: (_, __) => const HowToPlayScreen()),
     GoRoute(path: '/settings', builder: (_, __) => const SettingsScreen()),
   ],
 );

--- a/lib/core/widgets/first_visit_tip.dart
+++ b/lib/core/widgets/first_visit_tip.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../theme/app_theme.dart';
+import '../../features/settings/presentation/providers/app_preferences_provider.dart';
+
+/// Shows a dismissable tip card anchored to the bottom of its parent on the
+/// first time a user visits the screen identified by [screenId], provided that
+/// the global "tips" preference is enabled.
+///
+/// Wrap the screen's [Scaffold] body (or use it as an overlay sibling) and
+/// supply a unique [screenId], an icon, a short [title], and a [message].
+class FirstVisitTip extends ConsumerStatefulWidget {
+  final String screenId;
+  final IconData icon;
+  final String title;
+  final String message;
+
+  const FirstVisitTip({
+    super.key,
+    required this.screenId,
+    required this.icon,
+    required this.title,
+    required this.message,
+  });
+
+  @override
+  ConsumerState<FirstVisitTip> createState() => _FirstVisitTipState();
+}
+
+class _FirstVisitTipState extends ConsumerState<FirstVisitTip>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final Animation<Offset> _slide;
+  bool _dismissed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 320),
+    );
+    _slide = Tween<Offset>(begin: const Offset(0, 1), end: Offset.zero)
+        .animate(CurvedAnimation(parent: _ctrl, curve: Curves.easeOut));
+    // Delay slightly so the screen renders first.
+    Future.delayed(const Duration(milliseconds: 450), () {
+      if (mounted) _ctrl.forward();
+    });
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _dismiss() async {
+    await _ctrl.reverse();
+    if (mounted) setState(() => _dismissed = true);
+    await ref.read(appPreferencesProvider.notifier).markScreenSeen(widget.screenId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissed) return const SizedBox.shrink();
+
+    final prefsAsync = ref.watch(appPreferencesProvider);
+    return prefsAsync.when(
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (prefs) {
+        if (!prefs.tipsEnabled || prefs.hasSeenScreen(widget.screenId)) {
+          return const SizedBox.shrink();
+        }
+        final tt = Theme.of(context).textTheme;
+        return SlideTransition(
+          position: _slide,
+          child: SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: AppColors.stone,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: AppColors.torchAmber.withValues(alpha: 0.5)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.4),
+                      blurRadius: 12,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
+                ),
+                padding: const EdgeInsets.fromLTRB(14, 12, 14, 10),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(widget.icon, color: AppColors.torchAmber, size: 22),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(widget.title,
+                              style: tt.labelLarge?.copyWith(
+                                  color: AppColors.torchAmber,
+                                  fontWeight: FontWeight.bold)),
+                          const SizedBox(height: 4),
+                          Text(widget.message,
+                              style: tt.labelMedium?.copyWith(
+                                  color: AppColors.textLight.withValues(alpha: 0.85),
+                                  height: 1.4)),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    GestureDetector(
+                      onTap: _dismiss,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 10, vertical: 5),
+                        decoration: BoxDecoration(
+                          color: AppColors.torchAmber.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(6),
+                          border: Border.all(
+                              color: AppColors.torchAmber.withValues(alpha: 0.4)),
+                        ),
+                        child: Text('Got it',
+                            style: tt.labelSmall?.copyWith(
+                                color: AppColors.torchAmber,
+                                fontWeight: FontWeight.bold)),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/gameplay/presentation/screens/gameplay_screen.dart
+++ b/lib/features/gameplay/presentation/screens/gameplay_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/first_visit_tip.dart';
 import '../../data/topic_registry.dart';
 import '../../domain/models/game_state.dart';
 import '../../domain/models/quiz_config.dart';
@@ -186,49 +187,64 @@ class _GameplayScreenState extends ConsumerState<GameplayScreen> {
           streak: gs.streak,
           isEndless: gs.config.gameMode == GameMode.endless,
         ),
-        body: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 520),
-            child: Column(
-              children: [
-                _TopicIllustration(topicId: question.topicId),
-                Expanded(
-                  child: SingleChildScrollView(
-                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-                    child: Column(
-                      children: [
-                        if (gs.status == GameStatus.loading)
-                          const QuestionCardSkeleton()
-                        else ...[
-                          QuestionCard(
-                            question: question,
-                            onArticleTap: question.articleUrl.isEmpty
-                                ? null
-                                : () => context.push('/article', extra: {
-                                      'url': question.articleUrl,
-                                      'title': question.articleTitle,
-                                      'topicId': question.topicId,
-                                    }),
-                          ),
-                          const SizedBox(height: 14),
-                          _AnswerGrid(
-                            question: question,
-                            selectedIndex: _selectedIndex,
-                            onAnswer: (i) => _handleAnswer(i, question),
-                          ),
-                        ],
-                        const SizedBox(height: 16),
-                        _ProgressBar(
-                          current: gs.currentQuestionIndex + 1,
-                          total: gs.questions.length,
+        body: Stack(
+          children: [
+            Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 520),
+                child: Column(
+                  children: [
+                    _TopicIllustration(topicId: question.topicId),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                        child: Column(
+                          children: [
+                            if (gs.status == GameStatus.loading)
+                              const QuestionCardSkeleton()
+                            else ...[
+                              QuestionCard(
+                                question: question,
+                                onArticleTap: question.articleUrl.isEmpty
+                                    ? null
+                                    : () => context.push('/article', extra: {
+                                          'url': question.articleUrl,
+                                          'title': question.articleTitle,
+                                          'topicId': question.topicId,
+                                        }),
+                              ),
+                              const SizedBox(height: 14),
+                              _AnswerGrid(
+                                question: question,
+                                selectedIndex: _selectedIndex,
+                                onAnswer: (i) => _handleAnswer(i, question),
+                              ),
+                            ],
+                            const SizedBox(height: 16),
+                            _ProgressBar(
+                              current: gs.currentQuestionIndex + 1,
+                              total: gs.questions.length,
+                            ),
+                          ],
                         ),
-                      ],
+                      ),
                     ),
-                  ),
+                  ],
                 ),
-              ],
+              ),
             ),
-          ),
+            const Align(
+              alignment: Alignment.bottomCenter,
+              child: FirstVisitTip(
+                screenId: 'gameplay',
+                icon: Icons.menu_book,
+                title: 'Navigate the dungeon',
+                message: 'Tap 📖 on any question card to read its Wikipedia article. '
+                    'You have 3 ❤️ lives — a wrong answer costs one. '
+                    'After answering, tap "Read Article" in the pop-up to go deeper.',
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/settings/data/app_preferences_service.dart
+++ b/lib/features/settings/data/app_preferences_service.dart
@@ -1,0 +1,29 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists app-wide user preferences (tips toggle, seen-screen tracking).
+class AppPreferencesService {
+  static const _keyTipsEnabled = 'prefs_tips_enabled';
+  static const _keySeenScreens = 'prefs_seen_screens';
+
+  static Future<bool> getTipsEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_keyTipsEnabled) ?? true;
+  }
+
+  static Future<void> setTipsEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_keyTipsEnabled, value);
+  }
+
+  static Future<Set<String>> getSeenScreens() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(_keySeenScreens)?.toSet() ?? {};
+  }
+
+  static Future<void> markScreenSeen(String screenId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final seen = prefs.getStringList(_keySeenScreens)?.toSet() ?? {};
+    seen.add(screenId);
+    await prefs.setStringList(_keySeenScreens, seen.toList());
+  }
+}

--- a/lib/features/settings/presentation/providers/app_preferences_provider.dart
+++ b/lib/features/settings/presentation/providers/app_preferences_provider.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../data/app_preferences_service.dart';
+
+class AppPreferences {
+  final bool tipsEnabled;
+  final Set<String> seenScreens;
+
+  const AppPreferences({
+    required this.tipsEnabled,
+    required this.seenScreens,
+  });
+
+  bool hasSeenScreen(String screenId) => seenScreens.contains(screenId);
+}
+
+class AppPreferencesNotifier extends AsyncNotifier<AppPreferences> {
+  @override
+  Future<AppPreferences> build() async {
+    final tipsEnabled = await AppPreferencesService.getTipsEnabled();
+    final seenScreens = await AppPreferencesService.getSeenScreens();
+    return AppPreferences(tipsEnabled: tipsEnabled, seenScreens: seenScreens);
+  }
+
+  Future<void> setTipsEnabled(bool value) async {
+    await AppPreferencesService.setTipsEnabled(value);
+    ref.invalidateSelf();
+  }
+
+  Future<void> markScreenSeen(String screenId) async {
+    final current = await future;
+    if (current.hasSeenScreen(screenId)) return;
+    await AppPreferencesService.markScreenSeen(screenId);
+    ref.invalidateSelf();
+  }
+}
+
+final appPreferencesProvider =
+    AsyncNotifierProvider<AppPreferencesNotifier, AppPreferences>(
+  AppPreferencesNotifier.new,
+);

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
@@ -8,6 +9,7 @@ import '../../data/game_stats_repository.dart';
 import '../../data/user_profile_service.dart';
 import '../../domain/models/game_stats.dart';
 import '../../domain/models/user_profile.dart';
+import '../providers/app_preferences_provider.dart';
 
 // Common emoji options for the avatar picker.
 const _kEmojiOptions = [
@@ -15,14 +17,14 @@ const _kEmojiOptions = [
   '🐉', '🦁', '🦊', '🐺', '🦅', '🌙', '⭐', '🔮',
 ];
 
-class SettingsScreen extends StatefulWidget {
+class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
 
   @override
-  State<SettingsScreen> createState() => _SettingsScreenState();
+  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
 }
 
-class _SettingsScreenState extends State<SettingsScreen> {
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   UserProfile? _profile;
   GameStats? _stats;
   String? _appVersion;
@@ -292,6 +294,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
           ),
 
+          // ── Preferences ──────────────────────────────────────────────────
+          const _SectionHeader('Preferences'),
+          _TipsTile(ref: ref),
+
+          // ── Learn ─────────────────────────────────────────────────────────
+          const _SectionHeader('Learn'),
+          ListTile(
+            leading: const Icon(Icons.help_outline, color: AppColors.torchAmber),
+            title: const Text('How to Play',
+                style: TextStyle(color: AppColors.textLight)),
+            subtitle: Text(
+              'Lives, scoring, streaks, modes, and more',
+              style: tt.bodySmall?.copyWith(
+                  color: AppColors.textLight.withValues(alpha: 0.5)),
+            ),
+            trailing: const Icon(Icons.chevron_right, color: AppColors.stoneMid),
+            onTap: () => context.push('/how-to-play'),
+          ),
+
           // ── Feedback ─────────────────────────────────────────────────────
           const _SectionHeader('Feedback'),
           ListTile(
@@ -434,6 +455,35 @@ class _StatCell extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tips toggle tile
+// ---------------------------------------------------------------------------
+
+class _TipsTile extends StatelessWidget {
+  final WidgetRef ref;
+  const _TipsTile({required this.ref});
+
+  @override
+  Widget build(BuildContext context) {
+    final prefsAsync = ref.watch(appPreferencesProvider);
+    final enabled = prefsAsync.asData?.value.tipsEnabled ?? true;
+    return SwitchListTile(
+      secondary: const Icon(Icons.lightbulb_outline, color: AppColors.torchAmber),
+      title: const Text('Show tips',
+          style: TextStyle(color: AppColors.textLight)),
+      subtitle: Text(
+        'Hint cards shown on first visit to each screen',
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: AppColors.textLight.withValues(alpha: 0.5)),
+      ),
+      value: enabled,
+      activeThumbColor: AppColors.torchAmber,
+      onChanged: (v) =>
+          ref.read(appPreferencesProvider.notifier).setTipsEnabled(v),
     );
   }
 }

--- a/lib/features/start/presentation/screens/how_to_play_screen.dart
+++ b/lib/features/start/presentation/screens/how_to_play_screen.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_theme.dart';
+
+class HowToPlayScreen extends StatelessWidget {
+  const HowToPlayScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.stoneDark,
+        title: const Text('How to Play'),
+      ),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+            children: const [
+              _HeroCard(),
+              SizedBox(height: 16),
+              _Section(
+                icon: Icons.favorite,
+                title: 'Lives',
+                body:
+                    'You start every Standard game with 3 ❤️ lives. Each wrong answer '
+                    'costs one life. Lose all three and the quest ends. In Endless mode '
+                    'you still start with 3 lives but there is no question limit — play '
+                    'until the dungeon claims you.',
+              ),
+              _Section(
+                icon: Icons.military_tech,
+                title: 'Scoring',
+                body:
+                    'Every correct answer earns points. The exact value scales with the '
+                    'question difficulty: easy answers earn fewer points, hard ones earn '
+                    'more. Your total score is shown in the top-right corner during play '
+                    'and saved to your stats after the game.',
+              ),
+              _Section(
+                icon: Icons.local_fire_department,
+                title: 'Streaks & Rewards',
+                body:
+                    'Answer correctly several times in a row to build a streak 🔥 '
+                    '(Endless mode only). When your streak hits the limit for the '
+                    'current difficulty, you earn a reward:\n\n'
+                    '• If you have fewer than 3 lives → one life is restored ❤️\n'
+                    '• If you already have 3 lives → bonus points are awarded ⚡',
+              ),
+              _Section(
+                icon: Icons.tune,
+                title: 'Game Modes',
+                body:
+                    'Standard mode gives you 10 questions across your chosen topics. '
+                    'Complete all 10 without losing your last life to win.\n\n'
+                    'Endless mode keeps going until your lives run out. Your high score '
+                    'is tracked separately and shown on the results screen.',
+              ),
+              _Section(
+                icon: Icons.menu_book,
+                title: 'Wikipedia Links',
+                body:
+                    'Each question is linked to a Wikipedia article. Tap the 📖 icon '
+                    'on the question card to read it before answering.\n\n'
+                    'After you answer, the fun-fact sheet also shows a "Read Article" '
+                    'button so you can dive deeper before moving on.',
+              ),
+              _Section(
+                icon: Icons.book_outlined,
+                title: 'Notebook',
+                body:
+                    'Every Wikipedia article you open is saved to your Notebook. '
+                    'Access it from the start screen to revisit articles from past '
+                    'games — great for exploring topics you found interesting.',
+              ),
+              _Section(
+                icon: Icons.stars,
+                title: 'Stars & Results',
+                body:
+                    'At the end of a Standard game you earn 1–3 stars based on your '
+                    'score and accuracy:\n\n'
+                    '⭐⭐⭐ — All questions correct and high score\n'
+                    '⭐⭐ — At least 60 % answered, decent score\n'
+                    '⭐ — Any score above 10\n\n'
+                    'Endless mode shows your personal best instead of stars.',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hero card
+// ---------------------------------------------------------------------------
+
+class _HeroCard extends StatelessWidget {
+  const _HeroCard();
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.stone,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.torchAmber.withValues(alpha: 0.4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🏰', style: TextStyle(fontSize: 28)),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  'Welcome to the Dungeon',
+                  style: tt.displaySmall?.copyWith(
+                      color: AppColors.torchAmber, fontSize: 18),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            'Mind Mazeish is a trivia game set in a medieval castle. '
+            'Answer questions to advance through rooms, survive on lives, '
+            'and discover the Wikipedia articles behind every question.',
+            style: tt.labelMedium?.copyWith(
+                color: AppColors.textLight.withValues(alpha: 0.85), height: 1.5),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section card
+// ---------------------------------------------------------------------------
+
+class _Section extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String body;
+
+  const _Section({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: AppColors.stone.withValues(alpha: 0.5),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: AppColors.stoneMid),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, color: AppColors.torchAmber, size: 18),
+                const SizedBox(width: 8),
+                Text(
+                  title,
+                  style: tt.labelLarge?.copyWith(
+                      color: AppColors.torchAmber, fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              body,
+              style: tt.labelMedium?.copyWith(
+                  color: AppColors.textLight.withValues(alpha: 0.85),
+                  height: 1.5),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/start/presentation/screens/start_screen.dart
+++ b/lib/features/start/presentation/screens/start_screen.dart
@@ -12,6 +12,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/first_visit_tip.dart';
 import '../../../../services/update_service.dart';
 import '../../../gameplay/domain/models/quiz_config.dart';
 import '../../../gameplay/presentation/providers/game_state_provider.dart';
@@ -35,6 +36,20 @@ class StartScreen extends ConsumerWidget {
       body: Stack(
         children: [
           Positioned.fill(child: CustomPaint(painter: _StartBackgroundPainter())),
+          const SafeArea(
+            top: false,
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: FirstVisitTip(
+                screenId: 'start',
+                icon: Icons.bolt,
+                title: 'Welcome, adventurer!',
+                message: 'Tap Quick Play for a random 10-question game, '
+                    'or Choose Topics to pick which rooms to explore. '
+                    'Find How to Play in the menu below.',
+              ),
+            ),
+          ),
           SafeArea(
             child: Center(
               child: ConstrainedBox(
@@ -120,6 +135,18 @@ class StartScreen extends ConsumerWidget {
 
                     const SizedBox(height: 24),
 
+                    // How to Play button
+                    TextButton.icon(
+                      onPressed: () => context.push('/how-to-play'),
+                      icon: const Icon(Icons.help_outline,
+                          size: 18, color: AppColors.torchAmber),
+                      label: Text('How to Play',
+                          style: textTheme.labelMedium?.copyWith(
+                              color: AppColors.torchAmber)),
+                    ).animate().fadeIn(duration: 400.ms, delay: 800.ms),
+
+                    const SizedBox(height: 4),
+
                     // Notebook button
                     TextButton.icon(
                       onPressed: () => context.push('/notebook'),
@@ -128,7 +155,7 @@ class StartScreen extends ConsumerWidget {
                       label: Text('Notebook',
                           style: textTheme.labelMedium?.copyWith(
                               color: AppColors.torchAmber)),
-                    ).animate().fadeIn(duration: 400.ms, delay: 800.ms),
+                    ).animate().fadeIn(duration: 400.ms, delay: 860.ms),
 
                     const SizedBox(height: 4),
 
@@ -142,7 +169,7 @@ class StartScreen extends ConsumerWidget {
                           style: textTheme.labelMedium?.copyWith(
                               color: AppColors.textLight
                                   .withValues(alpha: 0.55))),
-                    ).animate().fadeIn(duration: 400.ms, delay: 900.ms),
+                    ).animate().fadeIn(duration: 400.ms, delay: 920.ms),
 
                     const SizedBox(height: 8),
                     _VersionBadge()

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 ### Features
-- (none)
+- Added a **"How to Play"** screen explaining lives, scoring, streaks, modes, wiki links, and the notebook; accessible from the start screen and from Settings (#59)
+- First-visit **tip cards** slide up on the Start and Gameplay screens to orient new players; tips auto-dismiss when tapped "Got it" and never reappear (#59)
+- New **Preferences** section in Settings with a "Show tips" toggle to enable or disable hint cards globally; setting is persisted across sessions (#59)
 
 ### Fixes
 - (none)


### PR DESCRIPTION
Closes #59

## Summary

- **How to Play screen** (`/how-to-play`) — scrollable reference covering lives, scoring, streaks, game modes, wiki links, and the notebook. Accessible from a new "How to Play" button on the start screen and from Settings → Learn.
- **First-visit tip cards** — `FirstVisitTip` widget (backed by `AppPreferencesNotifier`) shows an animated slide-up hint card on the first visit to the Start and Gameplay screens. Cards persist their "dismissed" state to SharedPreferences so they never repeat.
- **App Preferences** — `AppPreferencesService` + Riverpod `AsyncNotifierProvider` stores `tipsEnabled` (bool) and `seenScreens` (Set<String>) in SharedPreferences. Settings screen gains a "Preferences" section with a "Show tips" `SwitchListTile`.

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes (84 tests)
- [ ] Manual — fresh install: open Start screen, confirm the "Welcome, adventurer!" tip card slides up; tap "Got it", reopen app, confirm it no longer appears
- [ ] Manual — start a game, confirm the "Navigate the dungeon" tip appears on first play; tap "Got it", play again, confirm it's gone
- [ ] Manual — Settings → tap "How to Play", verify the screen opens with all sections (Lives, Scoring, Streaks, Modes, Wikipedia, Notebook, Stars)
- [ ] Manual — Settings → Preferences → toggle "Show tips" off, relaunch, confirm no tip cards appear anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)