### PR TITLE
fix: inject FEEDBACK_GITHUB_PAT into web build so feedback submission works

### DIFF
--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -40,7 +40,9 @@ jobs:
         run: flutter test --reporter expanded
 
       - name: Build web
-        run: flutter build web --release --base-href /Mind-mazeish/
+        env:
+          FEEDBACK_PAT: ${{ secrets.FEEDBACK_GITHUB_PAT }}
+        run: flutter build web --release --base-href /Mind-mazeish/ --dart-define=FEEDBACK_GITHUB_PAT=$FEEDBACK_PAT
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,7 @@
 - (none)
 
 ### Fixes
-- (none)
+- Fix feedback submission on web — inject FEEDBACK_GITHUB_PAT into the web build so users can submit feedback from the GitHub Pages app
 
 ### Content
 - (none)


### PR DESCRIPTION
The cd-web.yml workflow was building Flutter web without --dart-define=FEEDBACK_GITHUB_PAT,
so _kGithubToken was always empty at runtime. Every _createIssue() call returned false
immediately, showing "check your connection" to users. Mirrors the flag already present
in the APK build step.

https://claude.ai/code/session_015JT2QnSApt5XnhtJb9nfoz