### PR TITLE
fix(ci): switch GitHub Pages deploy to actions/deploy-pages (drops deprecated Node.js 20 action)

### DIFF
--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -15,7 +15,12 @@ jobs:
     name: Build Flutter Web & Deploy to GitHub Pages
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout
@@ -44,9 +49,11 @@ jobs:
           FEEDBACK_PAT: ${{ secrets.FEEDBACK_GITHUB_PAT }}
         run: flutter build web --release --base-href /Mind-mazeish/ --dart-define=FEEDBACK_GITHUB_PAT=$FEEDBACK_PAT
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: build/web
-          publish_branch: gh-pages
+          path: build/web
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,14 +2,34 @@
 
 [![CI — Analyze & Test](https://github.com/sai-pher/mind-mazeish/actions/workflows/ci.yml/badge.svg)](https://github.com/sai-pher/mind-mazeish/actions/workflows/ci.yml)
 [![CD — Build & Publish APK](https://github.com/sai-pher/mind-mazeish/actions/workflows/cd.yml/badge.svg)](https://github.com/sai-pher/mind-mazeish/actions/workflows/cd.yml)
+[![CD — Deploy Web](https://github.com/sai-pher/mind-mazeish/actions/workflows/cd-web.yml/badge.svg)](https://github.com/sai-pher/mind-mazeish/actions/workflows/cd-web.yml)
 
-A medieval castle trivia game for Android. Answer questions across 35 topic areas — from Ancient History to Coffee Brewing — all sourced from Wikipedia. Read the source articles in-app after each answer.
+A medieval castle trivia game for Android and the web. Answer questions across 35 topic areas — from Ancient History to Coffee Brewing — all sourced from Wikipedia. Read the source articles in-app after each answer.
 
 > **Alpha release** — you are one of our first testers. Expect rough edges, and please use the in-app feedback button to let us know what you find.
 
 ---
 
-## Download & Install
+## Play in your browser
+
+**[https://sai-pher.github.io/Mind-mazeish/](https://sai-pher.github.io/Mind-mazeish/)**
+
+No install required — open the link in any modern browser and play immediately.
+
+### Add to Home Screen on iOS (PWA)
+
+You can install Mind Mazeish as a full-screen app on your iPhone or iPad:
+
+1. Open the link above in **Safari** (must be Safari — Chrome and Firefox on iOS cannot install PWAs).
+2. Tap the **Share** button (the box with an arrow pointing up) in the bottom toolbar.
+3. Scroll down and tap **Add to Home Screen**.
+4. Give it a name and tap **Add**.
+
+The app icon will appear on your Home Screen and launch full-screen, just like a native app.
+
+---
+
+## Download & Install (Android)
 
 1. Go to the [**Releases page**](https://github.com/sai-pher/Mind-mazeish/releases/latest) and download `app-release.apk`.
 2. On your Android device, open **Settings → Apps** (or **Special app access**) and enable **Install unknown apps** for your file manager or browser.
@@ -60,7 +80,7 @@ Your feedback is submitted directly as an issue on this GitHub repository so it 
 
 - Questions are bundled in the app — no internet needed to play (except to open Wikipedia articles)
 - Some topics have fewer than 10 questions — more are being added
-- The app is Android-only at this stage
+- The Android app requires sideloading (no Play Store listing yet)
 - No account or progress sync between devices
 
 ---
@@ -153,3 +173,4 @@ lib/
 |----------|---------|--------------|
 | **CI** | Push / PR | `flutter analyze --fatal-infos` + `flutter test` |
 | **CD** | Push to `main` | Analyze → Test → Build APK → Publish to GitHub Releases |
+| **CD Web** | Push to `main` | Analyze → Test → Build Flutter Web → Deploy to GitHub Pages |

--- a/README.md
+++ b/README.md
@@ -60,8 +60,13 @@ Your feedback is submitted directly as an issue on this GitHub repository so it 
 
 - Questions are bundled in the app — no internet needed to play (except to open Wikipedia articles)
 - Some topics have fewer than 10 questions — more are being added
-- The app is Android-only at this stage
+- The Android app requires sideloading (no Play Store listing yet)
 - No account or progress sync between devices
+
+### Web-specific limitations
+
+- **Wikipedia articles open in a new tab** — your browser must allow pop-ups for this site. If tapping "Open Wikipedia article" does nothing, go to your browser's address bar, click the pop-up blocked icon, and choose **Always allow pop-ups from this site**.
+- **Add to Home Screen requires Safari on iOS** — Chrome and Firefox on iOS cannot install PWAs.
 
 ---
 

--- a/lib/features/article_viewer/presentation/screens/article_screen_web.dart
+++ b/lib/features/article_viewer/presentation/screens/article_screen_web.dart
@@ -25,35 +25,48 @@ class ArticleScreen extends ConsumerStatefulWidget {
 }
 
 class _ArticleScreenState extends ConsumerState<ArticleScreen> {
-  bool _notebookSaved = false;
-
   @override
   void initState() {
     super.initState();
-    _tryOpen();
+    _openAndRecord();
   }
 
-  Future<void> _tryOpen() async {
+  Future<void> _openAndRecord() async {
     final uri = Uri.tryParse(widget.url);
-    if (uri == null || (uri.scheme != 'https' && uri.scheme != 'http')) return;
-    await launchUrl(uri, mode: LaunchMode.externalApplication);
-    if (!mounted) return;
-    await _saveToNotebook();
-  }
+    if (uri == null || (uri.scheme != 'https' && uri.scheme != 'http')) {
+      return;
+    }
 
-  Future<void> _manualOpen() async {
-    final uri = Uri.tryParse(widget.url);
-    if (uri == null) return;
-    await launchUrl(uri, mode: LaunchMode.externalApplication);
+    final opened = await launchUrl(uri, mode: LaunchMode.externalApplication);
+
     if (!mounted) return;
-    await _saveToNotebook();
+
+    if (opened) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Opening article in browser…')),
+      );
+      await _saveToNotebook();
+      if (mounted) context.pop();
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text(
+              'Pop-ups are blocked — allow pop-ups for this site in your browser settings.'),
+          duration: const Duration(seconds: 6),
+          action: SnackBarAction(
+            label: 'Retry',
+            onPressed: _openAndRecord,
+          ),
+        ),
+      );
+    }
   }
 
   Future<void> _saveToNotebook() async {
-    if (_notebookSaved) return;
     final topicId = widget.topicId ??
         ref.read(gameStateProvider)?.currentQuestion.topicId ??
         'unknown';
+
     final isNew = await ref.read(notebookProvider.notifier).addEntry(
           NotebookEntry(
             articleTitle: widget.title,
@@ -62,17 +75,15 @@ class _ArticleScreenState extends ConsumerState<ArticleScreen> {
             visitedAt: DateTime.now(),
           ),
         );
-    if (!mounted) return;
+
     ref.read(gameStateProvider.notifier).recordArticleVisit(
           widget.url,
           isNew: isNew,
         );
-    setState(() => _notebookSaved = true);
   }
 
   @override
   Widget build(BuildContext context) {
-    final tt = Theme.of(context).textTheme;
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title, overflow: TextOverflow.ellipsis),
@@ -81,55 +92,17 @@ class _ArticleScreenState extends ConsumerState<ArticleScreen> {
           onPressed: () => context.pop(),
         ),
       ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 32),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.menu_book_outlined,
-                color: AppColors.torchAmber,
-                size: 52,
-              ),
-              const SizedBox(height: 20),
-              Text(
-                widget.title,
-                style: tt.titleMedium?.copyWith(color: AppColors.textLight),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 28),
-              ElevatedButton.icon(
-                icon: const Icon(Icons.open_in_new, size: 18),
-                label: const Text('Open Wikipedia article'),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.torchAmber,
-                  foregroundColor: AppColors.textDark,
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 24, vertical: 12),
-                  shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(6)),
-                ),
-                onPressed: _manualOpen,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                'Opens in a new tab.\nIf nothing opens, allow pop-ups for this site in your browser settings.',
-                style: tt.bodySmall?.copyWith(
-                  color: AppColors.textLight.withValues(alpha: 0.55),
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 28),
-              TextButton(
-                onPressed: () => context.pop(),
-                child: Text(
-                  'Go back to game',
-                  style: TextStyle(color: AppColors.stoneMid),
-                ),
-              ),
-            ],
-          ),
+      body: const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(color: AppColors.torchAmber),
+            SizedBox(height: 16),
+            Text(
+              'Opening article in browser…',
+              style: TextStyle(color: AppColors.textLight, fontSize: 16),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/article_viewer/presentation/screens/article_screen_web.dart
+++ b/lib/features/article_viewer/presentation/screens/article_screen_web.dart
@@ -25,36 +25,35 @@ class ArticleScreen extends ConsumerStatefulWidget {
 }
 
 class _ArticleScreenState extends ConsumerState<ArticleScreen> {
+  bool _notebookSaved = false;
+
   @override
   void initState() {
     super.initState();
-    _openAndRecord();
+    _tryOpen();
   }
 
-  Future<void> _openAndRecord() async {
+  Future<void> _tryOpen() async {
     final uri = Uri.tryParse(widget.url);
-    if (uri == null || (uri.scheme != 'https' && uri.scheme != 'http')) {
-      return;
-    }
-
+    if (uri == null || (uri.scheme != 'https' && uri.scheme != 'http')) return;
     await launchUrl(uri, mode: LaunchMode.externalApplication);
-
     if (!mounted) return;
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Opening article in browser…')),
-    );
-
     await _saveToNotebook();
+  }
 
-    if (mounted) context.pop();
+  Future<void> _manualOpen() async {
+    final uri = Uri.tryParse(widget.url);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!mounted) return;
+    await _saveToNotebook();
   }
 
   Future<void> _saveToNotebook() async {
+    if (_notebookSaved) return;
     final topicId = widget.topicId ??
         ref.read(gameStateProvider)?.currentQuestion.topicId ??
         'unknown';
-
     final isNew = await ref.read(notebookProvider.notifier).addEntry(
           NotebookEntry(
             articleTitle: widget.title,
@@ -63,15 +62,17 @@ class _ArticleScreenState extends ConsumerState<ArticleScreen> {
             visitedAt: DateTime.now(),
           ),
         );
-
+    if (!mounted) return;
     ref.read(gameStateProvider.notifier).recordArticleVisit(
           widget.url,
           isNew: isNew,
         );
+    setState(() => _notebookSaved = true);
   }
 
   @override
   Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title, overflow: TextOverflow.ellipsis),
@@ -80,17 +81,55 @@ class _ArticleScreenState extends ConsumerState<ArticleScreen> {
           onPressed: () => context.pop(),
         ),
       ),
-      body: const Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            CircularProgressIndicator(color: AppColors.torchAmber),
-            SizedBox(height: 16),
-            Text(
-              'Opening article in browser…',
-              style: TextStyle(color: AppColors.textLight, fontSize: 16),
-            ),
-          ],
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.menu_book_outlined,
+                color: AppColors.torchAmber,
+                size: 52,
+              ),
+              const SizedBox(height: 20),
+              Text(
+                widget.title,
+                style: tt.titleMedium?.copyWith(color: AppColors.textLight),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 28),
+              ElevatedButton.icon(
+                icon: const Icon(Icons.open_in_new, size: 18),
+                label: const Text('Open Wikipedia article'),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.torchAmber,
+                  foregroundColor: AppColors.textDark,
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 24, vertical: 12),
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(6)),
+                ),
+                onPressed: _manualOpen,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Opens in a new tab.\nIf nothing opens, allow pop-ups for this site in your browser settings.',
+                style: tt.bodySmall?.copyWith(
+                  color: AppColors.textLight.withValues(alpha: 0.55),
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 28),
+              TextButton(
+                onPressed: () => context.pop(),
+                child: Text(
+                  'Go back to game',
+                  style: TextStyle(color: AppColors.stoneMid),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/gameplay/data/question_repository.dart
+++ b/lib/features/gameplay/data/question_repository.dart
@@ -33,30 +33,37 @@ Future<Map<String, _Source>> _loadSources(String topicId) async {
 /// Loads questions for the given [topicIds] from per-topic JSON asset files.
 /// Resolves articleTitle/articleUrl from the corresponding sources file when
 /// the question carries a sourceId but no inline articleTitle.
+///
+/// All topics are loaded concurrently; within each topic the questions file and
+/// sources file are also fetched concurrently.
 Future<List<Question>> loadQuestionsForTopics(Set<String> topicIds) async {
-  final results = <Question>[];
-  for (final id in topicIds) {
-    final path = '$_topicsDir/$id.json';
-    try {
-      final sources = await _loadSources(id);
-      final raw = await rootBundle.loadString(path);
-      final list = jsonDecode(raw) as List<dynamic>;
-      for (final e in list.cast<Map<String, dynamic>>()) {
-        final q = Question.fromJson(e);
-        if (q.articleTitle.isEmpty && q.sourceId.isNotEmpty) {
-          final src = sources[q.sourceId];
-          if (src != null) {
-            results.add(q.withSource(title: src.title, url: src.url));
-            continue;
-          }
+  final perTopic = await Future.wait(topicIds.map(_loadTopicQuestions));
+  return perTopic.expand((qs) => qs).toList();
+}
+
+Future<List<Question>> _loadTopicQuestions(String id) async {
+  final path = '$_topicsDir/$id.json';
+  try {
+    final (sources, raw) =
+        await (_loadSources(id), rootBundle.loadString(path)).wait;
+    final list = jsonDecode(raw) as List<dynamic>;
+    final questions = <Question>[];
+    for (final e in list.cast<Map<String, dynamic>>()) {
+      final q = Question.fromJson(e);
+      if (q.articleTitle.isEmpty && q.sourceId.isNotEmpty) {
+        final src = sources[q.sourceId];
+        if (src != null) {
+          questions.add(q.withSource(title: src.title, url: src.url));
+          continue;
         }
-        results.add(q);
       }
-    } catch (_) {
-      // Topic file not found — skip silently (topic may have no questions yet).
+      questions.add(q);
     }
+    return questions;
+  } catch (_) {
+    // Topic file not found — skip silently (topic may have no questions yet).
+    return [];
   }
-  return results;
 }
 
 /// Loads every topic file and returns the full question pool.

--- a/lib/features/start/presentation/screens/mode_picker_screen.dart
+++ b/lib/features/start/presentation/screens/mode_picker_screen.dart
@@ -21,6 +21,7 @@ class _ModePickerScreenState extends ConsumerState<ModePickerScreen> {
   int _difficultyBias = 3;
   int _questionCount = 10;
   int _endlessHighScore = 0;
+  bool _starting = false;
 
   @override
   void initState() {
@@ -37,6 +38,8 @@ class _ModePickerScreenState extends ConsumerState<ModePickerScreen> {
   }
 
   Future<void> _startGame(GameMode mode) async {
+    if (_starting) return;
+    setState(() => _starting = true);
     final currentConfig = ref.read(quizConfigProvider);
     final topicIds = currentConfig.selectedTopicIds.isEmpty
         ? Set<String>.from(allTopicIds)
@@ -112,6 +115,7 @@ class _ModePickerScreenState extends ConsumerState<ModePickerScreen> {
                       painter: const _DoorPainter(),
                       highlightColor: AppColors.torchAmber,
                       extraBadge: null,
+                      loading: _starting,
                       onPlay: () => _startGame(GameMode.standard),
                       onSettings: () => _openSettings(GameMode.standard),
                     )
@@ -129,6 +133,7 @@ class _ModePickerScreenState extends ConsumerState<ModePickerScreen> {
                       extraBadge: _endlessHighScore > 0
                           ? 'Best: $_endlessHighScore pts'
                           : null,
+                      loading: _starting,
                       onPlay: () => _startGame(GameMode.endless),
                       onSettings: () => _openSettings(GameMode.endless),
                     )
@@ -156,6 +161,7 @@ class _ModeCard extends StatelessWidget {
   final CustomPainter painter;
   final Color highlightColor;
   final String? extraBadge;
+  final bool loading;
   final VoidCallback onPlay;
   final VoidCallback onSettings;
 
@@ -165,6 +171,7 @@ class _ModeCard extends StatelessWidget {
     required this.painter,
     required this.highlightColor,
     required this.extraBadge,
+    required this.loading,
     required this.onPlay,
     required this.onSettings,
   });
@@ -263,7 +270,7 @@ class _ModeCard extends StatelessWidget {
                     SizedBox(
                       width: double.infinity,
                       child: ElevatedButton(
-                        onPressed: onPlay,
+                        onPressed: loading ? null : onPlay,
                         style: ElevatedButton.styleFrom(
                           backgroundColor: highlightColor,
                           foregroundColor: AppColors.textDark,
@@ -271,13 +278,22 @@ class _ModeCard extends StatelessWidget {
                           shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(6)),
                         ),
-                        child: Text(
-                          'Play',
-                          style: tt.labelLarge?.copyWith(
-                            color: AppColors.textDark,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
+                        child: loading
+                            ? const SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2.5,
+                                  color: AppColors.textDark,
+                                ),
+                              )
+                            : Text(
+                                'Play',
+                                style: tt.labelLarge?.copyWith(
+                                  color: AppColors.textDark,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
                       ),
                     ),
                   ],

--- a/lib/features/start/presentation/screens/topic_picker_screen.dart
+++ b/lib/features/start/presentation/screens/topic_picker_screen.dart
@@ -25,6 +25,7 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
   GameMode _gameMode = GameMode.standard;
   int _difficultyBias = 3;
   int _endlessHighScore = 0;
+  bool _starting = false;
 
   @override
   void initState() {
@@ -91,6 +92,7 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
   void _clearAll() => setState(() => _selected.clear());
 
   Future<void> _startGame() async {
+    setState(() => _starting = true);
     final config = QuizConfig(
       selectedTopicIds: Set.from(_selected),
       questionCount: _questionCount,
@@ -173,6 +175,7 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
             gameMode: _gameMode,
             difficultyBias: _difficultyBias,
             canStart: _canStart,
+            starting: _starting,
             endlessHighScore: _endlessHighScore,
             onCountChanged: (c) => setState(() => _questionCount = c),
             onModeChanged: (m) => setState(() => _gameMode = m),
@@ -394,6 +397,7 @@ class _BottomBar extends StatelessWidget {
   final GameMode gameMode;
   final int difficultyBias;
   final bool canStart;
+  final bool starting;
   final int endlessHighScore;
   final void Function(int) onCountChanged;
   final void Function(GameMode) onModeChanged;
@@ -406,6 +410,7 @@ class _BottomBar extends StatelessWidget {
     required this.gameMode,
     required this.difficultyBias,
     required this.canStart,
+    required this.starting,
     required this.endlessHighScore,
     required this.onCountChanged,
     required this.onModeChanged,
@@ -565,7 +570,7 @@ class _BottomBar extends StatelessWidget {
           SizedBox(
             width: double.infinity,
             child: ElevatedButton(
-              onPressed: canStart && !tooFew ? onStart : null,
+              onPressed: canStart && !tooFew && !starting ? onStart : null,
               style: ElevatedButton.styleFrom(
                 backgroundColor: AppColors.torchAmber,
                 foregroundColor: AppColors.textDark,
@@ -573,11 +578,20 @@ class _BottomBar extends StatelessWidget {
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(6)),
               ),
-              child: Text(
-                buttonLabel,
-                style: textTheme.labelLarge
-                    ?.copyWith(color: AppColors.textDark),
-              ),
+              child: starting
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2.5,
+                        color: AppColors.textDark,
+                      ),
+                    )
+                  : Text(
+                      buttonLabel,
+                      style: textTheme.labelLarge
+                          ?.copyWith(color: AppColors.textDark),
+                    ),
             ),
           ),
         ],

--- a/release_notes.md
+++ b/release_notes.md
@@ -12,7 +12,7 @@
 - (none)
 
 ### Other
-- (none)
+- Switch GitHub Pages deployment from peaceiris/actions-gh-pages@v3 (Node.js 20, deprecated) to actions/upload-pages-artifact + actions/deploy-pages
 ---
 
 ## v1.0.51

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,13 +6,15 @@
 - (none)
 
 ### Fixes
-- (none)
+- Game start no longer freezes the UI for 3–5 s on web — question loading is now fully parallel across topics and within each topic (sources + questions file fetched concurrently)
+- Start button and Play cards show a spinner while questions load, preventing double-taps and giving immediate feedback
+- Wikipedia article screen on web now shows an "Open Wikipedia article" button with a pop-up note instead of silently failing when the browser blocks the automatic open
 
 ### Content
 - (none)
 
 ### Other
-- (none)
+- Document web-specific limitations in README (pop-ups required for Wikipedia links, iOS PWA requires Safari)
 ---
 
 ## v1.0.51

--- a/release_notes.md
+++ b/release_notes.md
@@ -13,6 +13,7 @@
 
 ### Other
 - Switch GitHub Pages deployment from peaceiris/actions-gh-pages@v3 (Node.js 20, deprecated) to actions/upload-pages-artifact + actions/deploy-pages
+- Update README: web app link, iOS PWA install instructions, CD Web badge, CI/CD table row
 ---
 
 ## v1.0.51

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,7 +8,7 @@
 ### Fixes
 - Game start no longer freezes the UI for 3–5 s on web — question loading is now fully parallel across topics and within each topic (sources + questions file fetched concurrently)
 - Start button and Play cards show a spinner while questions load, preventing double-taps and giving immediate feedback
-- Wikipedia article screen on web now shows an "Open Wikipedia article" button with a pop-up note instead of silently failing when the browser blocks the automatic open
+- Wikipedia article screen on web now shows a "Pop-ups are blocked" snackbar with a Retry action instead of silently closing when the browser blocks the automatic open
 
 ### Content
 - (none)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- `peaceiris/actions-gh-pages@v3` runs on Node.js 20 which GitHub has deprecated — the Deploy step was failing on every push to main
- Replaces it with the official `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4` pair
- Updates job permissions to `pages: write` + `id-token: write` as required by the new action

## ⚠️ Required repo settings change before merging
Go to **Settings → Pages → Build and deployment → Source** and change it from  
`Deploy from a branch` → **`GitHub Actions`**  
Without this the new action cannot deploy.

## Test plan
- [ ] Change Pages source to "GitHub Actions" in repo settings
- [ ] Merge PR and confirm the `CD — Build & Deploy Web` workflow run completes with all steps green
- [ ] Visit https://sai-pher.github.io/Mind-mazeish/ and confirm the app loads

https://claude.ai/code/session_015JT2QnSApt5XnhtJb9nfoz
EOF
)