### PR TITLE
fix+feat: bug report drafts (#110), game mode settings (#112), PR badge fix (#114)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"$(uname)\" = Linux ] && bash scripts/setup_flutter.sh || true"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash(git push:*)",

--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -50,7 +50,7 @@ jobs:
         run: flutter build web --release --base-href /Mind-mazeish/ --dart-define=FEEDBACK_GITHUB_PAT=$FEEDBACK_PAT
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: build/web
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,36 @@ lib/
         └── examples.md              # workflow examples + new-topic guide
 ```
 
+## Flutter setup (Linux)
+
+On Linux, Flutter is not pre-installed. A `SessionStart` hook in
+`.claude/settings.json` runs `scripts/setup_flutter.sh` automatically at the
+start of every session. The script:
+
+1. Checks whether `/opt/flutter/bin/flutter` is already at the required version (3.41.6).
+2. If not, downloads the tarball from the Flutter storage CDN and extracts it to `/opt/flutter`.
+3. Adds `/opt/flutter` to `git config --global safe.directory` (required when running as root).
+4. Runs `flutter pub get`.
+
+To run it manually:
+```bash
+bash scripts/setup_flutter.sh
+```
+
+To install Flutter by hand (the same steps the script performs):
+```bash
+FLUTTER_VERSION="3.41.6"
+curl -fSL "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" \
+  -o /tmp/flutter.tar.xz
+rm -rf /opt/flutter
+tar xf /tmp/flutter.tar.xz -C /opt/
+rm /tmp/flutter.tar.xz
+git config --global --add safe.directory /opt/flutter
+```
+
 ## Running checks
 ```bash
 export PATH="$PATH:/opt/flutter/bin"
-git config --global --add safe.directory /opt/flutter  # needed when running as root
 flutter pub get
 flutter analyze --fatal-infos
 flutter test --reporter expanded

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'core/theme/app_theme.dart';
+import 'features/gameplay/domain/models/quiz_config.dart';
 import 'features/start/presentation/screens/start_screen.dart';
 import 'features/start/presentation/screens/topic_picker_screen.dart';
 import 'features/gameplay/presentation/screens/gameplay_screen.dart';
@@ -13,13 +14,30 @@ import 'features/feedback/presentation/screens/feedback_screen.dart';
 import 'features/start/presentation/screens/question_stats_screen.dart';
 import 'features/start/presentation/screens/how_to_play_screen.dart';
 import 'features/start/presentation/screens/mode_picker_screen.dart';
+import 'features/start/presentation/screens/game_settings_screen.dart';
 import 'features/settings/presentation/screens/settings_screen.dart';
 
 final _router = GoRouter(
   initialLocation: '/',
   routes: [
     GoRoute(path: '/', builder: (_, __) => const StartScreen()),
-    GoRoute(path: '/topics', builder: (_, __) => const TopicPickerScreen()),
+    GoRoute(
+      path: '/topics',
+      builder: (_, state) {
+        final extra = state.extra as Map<String, dynamic>?;
+        return TopicPickerScreen(
+          fromSettings: extra?['fromSettings'] == true,
+        );
+      },
+    ),
+    GoRoute(
+      path: '/game-settings',
+      builder: (_, state) {
+        final extra = state.extra as Map<String, dynamic>?;
+        final mode = extra?['mode'] as GameMode? ?? GameMode.standard;
+        return GameSettingsScreen(mode: mode);
+      },
+    ),
     GoRoute(path: '/game', builder: (_, __) => const GameplayScreen()),
     GoRoute(
       path: '/article',

--- a/lib/features/feedback/data/feedback_draft_repository.dart
+++ b/lib/features/feedback/data/feedback_draft_repository.dart
@@ -15,11 +15,16 @@ class FeedbackDraft {
   final DateTime updatedAt;
 
   // Field name constants for each type.
-  static const fieldTitle       = 'title';
-  static const fieldBody        = 'body';
-  static const fieldCategory    = 'category';   // general
-  static const fieldRequestType = 'requestType'; // content
-  static const fieldTopicId     = 'topicId';     // content
+  static const fieldTitle          = 'title';
+  static const fieldBody           = 'body';
+  static const fieldCategory       = 'category';        // general
+  static const fieldRequestType    = 'requestType';     // content
+  static const fieldTopicId        = 'topicId';         // content
+  static const fieldGiven          = 'given';           // bug
+  static const fieldWhen           = 'when';            // bug
+  static const fieldThenExpected   = 'thenExpected';    // bug
+  static const fieldButActually    = 'butActually';     // bug
+  static const fieldSupportingDetails = 'supportingDetails'; // bug
 
   const FeedbackDraft({
     required this.id,

--- a/lib/features/feedback/data/github_issue_service.dart
+++ b/lib/features/feedback/data/github_issue_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
-/// Injected at build time via --dart-define=FEEDBACK_GITHUB_PAT=<token>
+/// Injected at build time via --dart-define=FEEDBACK_GITHUB_PAT=[token]
 /// Never hard-code the token here. See README → "Wiring up the feedback PAT".
 const _kGithubToken = String.fromEnvironment('FEEDBACK_GITHUB_PAT');
 const _kRepoOwner   = 'sai-pher';
@@ -253,7 +253,7 @@ ${attribution != null ? '**Submitted by:** $attribution\n' : userId != null ? '*
       if (response.statusCode != 200) return {};
       final prs = jsonDecode(response.body) as List;
       final referenced = <int>{};
-      final pattern = RegExp(r'(?:closes?|fixes?|resolves?)\s+#(\d+)', caseSensitive: false);
+      final pattern = RegExp(r'(?:closes?|fix(?:es)?|resolves?)\s+#(\d+)', caseSensitive: false);
       for (final pr in prs) {
         final title = (pr['title'] as String?) ?? '';
         final body = (pr['body'] as String?) ?? '';

--- a/lib/features/feedback/data/github_issue_service.dart
+++ b/lib/features/feedback/data/github_issue_service.dart
@@ -253,7 +253,7 @@ ${attribution != null ? '**Submitted by:** $attribution\n' : userId != null ? '*
       if (response.statusCode != 200) return {};
       final prs = jsonDecode(response.body) as List;
       final referenced = <int>{};
-      final pattern = RegExp(r'(?:closes?|fixes?|resolves?|#)\s*#?(\d+)', caseSensitive: false);
+      final pattern = RegExp(r'(?:closes?|fixes?|resolves?)\s+#(\d+)', caseSensitive: false);
       for (final pr in prs) {
         final title = (pr['title'] as String?) ?? '';
         final body = (pr['body'] as String?) ?? '';

--- a/lib/features/feedback/presentation/screens/feedback_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_screen.dart
@@ -11,8 +11,9 @@ import '../../../settings/domain/models/user_profile.dart';
 import '../../data/github_issue_service.dart';
 
 // Tab indices
-const _kTabGeneral  = 0;
-const _kTabContent  = 2;
+const _kTabGeneral    = 0;
+const _kTabBugReport  = 1;
+const _kTabContent    = 2;
 
 
 class FeedbackScreen extends StatefulWidget {
@@ -59,9 +60,12 @@ class _FeedbackScreenState extends State<FeedbackScreen>
 
   void _loadDraft(FeedbackDraft draft) {
     setState(() => _loadedDraft = draft);
-    _tabs.animateTo(
-      draft.type == 'general' ? _kTabGeneral : _kTabContent,
-    );
+    final tabIndex = switch (draft.type) {
+      'bug'     => _kTabBugReport,
+      'content' => _kTabContent,
+      _         => _kTabGeneral,
+    };
+    _tabs.animateTo(tabIndex);
   }
 
   @override
@@ -95,7 +99,12 @@ class _FeedbackScreenState extends State<FeedbackScreen>
             onDraftLoaded: _onDraftLoaded,
             onDraftSaved: _onDraftSaved,
           ),
-          _BugReportTab(appVersion: _appVersion),
+          _BugReportTab(
+            appVersion: _appVersion,
+            loadedDraft: _loadedDraft?.type == 'bug' ? _loadedDraft : null,
+            onDraftLoaded: _onDraftLoaded,
+            onDraftSaved: _onDraftSaved,
+          ),
           _ContentRequestTab(
             appVersion: _appVersion,
             profile: _profile,
@@ -315,7 +324,16 @@ class _GeneralFeedbackTabState extends State<_GeneralFeedbackTab> {
 
 class _BugReportTab extends StatefulWidget {
   final String? appVersion;
-  const _BugReportTab({this.appVersion});
+  final FeedbackDraft? loadedDraft;
+  final VoidCallback onDraftLoaded;
+  final VoidCallback onDraftSaved;
+
+  const _BugReportTab({
+    this.appVersion,
+    this.loadedDraft,
+    required this.onDraftLoaded,
+    required this.onDraftSaved,
+  });
 
   @override
   State<_BugReportTab> createState() => _BugReportTabState();
@@ -329,6 +347,22 @@ class _BugReportTabState extends State<_BugReportTab> {
   final _butActuallyCtrl    = TextEditingController();
   final _supportingCtrl     = TextEditingController();
   bool _submitting = false;
+  final _repo = FeedbackDraftRepository();
+
+  @override
+  void didUpdateWidget(_BugReportTab old) {
+    super.didUpdateWidget(old);
+    final draft = widget.loadedDraft;
+    if (draft != null && draft != old.loadedDraft) {
+      _titleCtrl.text        = draft.fields[FeedbackDraft.fieldTitle] ?? '';
+      _givenCtrl.text        = draft.fields[FeedbackDraft.fieldGiven] ?? '';
+      _whenCtrl.text         = draft.fields[FeedbackDraft.fieldWhen] ?? '';
+      _thenExpectedCtrl.text = draft.fields[FeedbackDraft.fieldThenExpected] ?? '';
+      _butActuallyCtrl.text  = draft.fields[FeedbackDraft.fieldButActually] ?? '';
+      _supportingCtrl.text   = draft.fields[FeedbackDraft.fieldSupportingDetails] ?? '';
+      widget.onDraftLoaded();
+    }
+  }
 
   @override
   void dispose() {
@@ -339,6 +373,33 @@ class _BugReportTabState extends State<_BugReportTab> {
     _butActuallyCtrl.dispose();
     _supportingCtrl.dispose();
     super.dispose();
+  }
+
+  Future<void> _saveDraft() async {
+    if (_titleCtrl.text.trim().isEmpty &&
+        _givenCtrl.text.trim().isEmpty &&
+        _whenCtrl.text.trim().isEmpty) {
+      _showSnack('Nothing to save — fill in at least a title or description.');
+      return;
+    }
+    final draft = FeedbackDraft(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      type: 'bug',
+      fields: {
+        FeedbackDraft.fieldTitle:           _titleCtrl.text,
+        FeedbackDraft.fieldGiven:           _givenCtrl.text,
+        FeedbackDraft.fieldWhen:            _whenCtrl.text,
+        FeedbackDraft.fieldThenExpected:    _thenExpectedCtrl.text,
+        FeedbackDraft.fieldButActually:     _butActuallyCtrl.text,
+        FeedbackDraft.fieldSupportingDetails: _supportingCtrl.text,
+      },
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+    await _repo.save(draft);
+    if (!mounted) return;
+    widget.onDraftSaved();
+    _showSnack('Draft saved — find it in the Pending tab.');
   }
 
   Future<void> _submit() async {
@@ -437,25 +498,41 @@ class _BugReportTabState extends State<_BugReportTab> {
             maxLines: 4,
           ),
           const SizedBox(height: 24),
-          SizedBox(
-            width: double.infinity,
-            child: ElevatedButton.icon(
-              onPressed: _submitting ? null : _submit,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.dangerRed,
-                foregroundColor: AppColors.textLight,
-                padding: const EdgeInsets.symmetric(vertical: 14),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: _saveDraft,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: AppColors.textLight,
+                    side: const BorderSide(color: AppColors.stoneMid),
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  icon: const Icon(Icons.save_outlined, size: 18),
+                  label: const Text('Save Draft'),
+                ),
               ),
-              icon: _submitting
-                  ? const SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(
-                          strokeWidth: 2, color: AppColors.textLight))
-                  : const Icon(Icons.bug_report),
-              label: Text(_submitting ? 'Submitting…' : 'Submit Bug Report',
-                  style: const TextStyle(fontWeight: FontWeight.bold)),
-            ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton.icon(
+                  onPressed: _submitting ? null : _submit,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.dangerRed,
+                    foregroundColor: AppColors.textLight,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  icon: _submitting
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                              strokeWidth: 2, color: AppColors.textLight))
+                      : const Icon(Icons.bug_report),
+                  label: Text(_submitting ? 'Submitting…' : 'Submit Bug Report',
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
+                ),
+              ),
+            ],
           ),
           if (widget.appVersion != null) ...[
             const SizedBox(height: 12),
@@ -805,8 +882,11 @@ class _PendingFeedbackTabState extends State<_PendingFeedbackTab> {
           separatorBuilder: (_, __) => const SizedBox(height: 8),
           itemBuilder: (context, i) {
             final draft = drafts[i];
-            final typeLabel =
-                draft.type == 'general' ? '💬 General' : '📚 Content';
+            final typeLabel = switch (draft.type) {
+              'bug'     => '🐛 Bug Report',
+              'content' => '📚 Content',
+              _         => '💬 General',
+            };
             final updated = _formatRelative(draft.updatedAt);
             return Card(
               color: AppColors.stone,

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -312,6 +312,19 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             trailing: const Icon(Icons.chevron_right, color: AppColors.stoneMid),
             onTap: () => context.push('/how-to-play'),
           ),
+          ListTile(
+            leading:
+                const Icon(Icons.library_books_outlined, color: AppColors.torchAmber),
+            title: const Text('Question Bank',
+                style: TextStyle(color: AppColors.textLight)),
+            subtitle: Text(
+              'Browse questions by topic and difficulty',
+              style: tt.bodySmall?.copyWith(
+                  color: AppColors.textLight.withValues(alpha: 0.5)),
+            ),
+            trailing: const Icon(Icons.chevron_right, color: AppColors.stoneMid),
+            onTap: () => context.push('/stats'),
+          ),
 
           // ── Feedback ─────────────────────────────────────────────────────
           const _SectionHeader('Feedback'),

--- a/lib/features/start/presentation/screens/game_settings_screen.dart
+++ b/lib/features/start/presentation/screens/game_settings_screen.dart
@@ -26,7 +26,7 @@ String _difficultyDescription(int bias, GameMode mode) {
   };
   if (mode == GameMode.endless) {
     final streakLimit = QuizConfig(
-      selectedTopicIds: const {},
+      selectedTopicIds: const <String>{},
       questionCount: 10,
       gameMode: GameMode.endless,
       difficultyBias: bias,

--- a/lib/features/start/presentation/screens/game_settings_screen.dart
+++ b/lib/features/start/presentation/screens/game_settings_screen.dart
@@ -1,0 +1,366 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../gameplay/data/topic_registry.dart';
+import '../../../gameplay/domain/models/quiz_config.dart';
+import '../../../gameplay/presentation/providers/game_state_provider.dart';
+import '../../../gameplay/presentation/providers/quiz_config_provider.dart';
+
+const _kDifficultyLabels = [
+  'Very Easy',
+  'Easy',
+  'Medium',
+  'Hard',
+  'Very Hard',
+];
+
+String _difficultyDescription(int bias, GameMode mode) {
+  final base = switch (bias) {
+    1 => 'Only the easiest questions — perfect for newcomers.',
+    2 => 'Mostly easy questions with a few harder ones.',
+    4 => 'Mostly challenging questions with fewer easy ones.',
+    5 => 'Only the toughest questions — for true masters.',
+    _ => 'A balanced mix across all difficulty levels.',
+  };
+  if (mode == GameMode.endless) {
+    final streakLimit = QuizConfig(
+      selectedTopicIds: const {},
+      questionCount: 10,
+      gameMode: GameMode.endless,
+      difficultyBias: bias,
+    ).streakLimit;
+    return '$base Get $streakLimit right in a row to earn hearts or bonus points.';
+  }
+  return base;
+}
+
+Color _biasColor(int bias) => switch (bias) {
+      1 || 2 => AppColors.torchGold,
+      4 || 5 => AppColors.dangerRed,
+      _ => AppColors.torchAmber,
+    };
+
+class GameSettingsScreen extends ConsumerStatefulWidget {
+  final GameMode mode;
+
+  const GameSettingsScreen({super.key, required this.mode});
+
+  @override
+  ConsumerState<GameSettingsScreen> createState() => _GameSettingsScreenState();
+}
+
+class _GameSettingsScreenState extends ConsumerState<GameSettingsScreen> {
+  late int _difficultyBias;
+  late int _questionCount;
+  bool _starting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final config = ref.read(quizConfigProvider);
+    _difficultyBias = config.difficultyBias;
+    _questionCount = config.questionCount;
+  }
+
+  bool get _isStandard => widget.mode == GameMode.standard;
+
+  int get _topicCount =>
+      ref.watch(quizConfigProvider).selectedTopicIds.length;
+
+  bool get _allTopicsSelected => _topicCount == allTopicIds.length;
+
+  Future<void> _startGame() async {
+    if (_starting) return;
+    setState(() => _starting = true);
+    final currentTopics = ref.read(quizConfigProvider).selectedTopicIds;
+    final topicIds =
+        currentTopics.isEmpty ? Set<String>.from(allTopicIds) : currentTopics;
+    final config = QuizConfig(
+      selectedTopicIds: topicIds,
+      questionCount: _questionCount,
+      gameMode: widget.mode,
+      difficultyBias: _difficultyBias,
+    );
+    ref.read(quizConfigProvider.notifier).setConfig(config);
+    await ref.read(gameStateProvider.notifier).startGame(config);
+    if (mounted) context.go('/game');
+  }
+
+  void _openTopics() {
+    final currentConfig = ref.read(quizConfigProvider);
+    ref.read(quizConfigProvider.notifier).setConfig(
+      currentConfig.copyWith(
+        gameMode: widget.mode,
+        difficultyBias: _difficultyBias,
+        questionCount: _questionCount,
+      ),
+    );
+    context.push('/topics', extra: {'fromSettings': true});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    final difficultyLabel = _kDifficultyLabels[_difficultyBias - 1];
+    final difficultyColor = _biasColor(_difficultyBias);
+    final description = _difficultyDescription(_difficultyBias, widget.mode);
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.stoneDark,
+        title: Text(_isStandard ? 'Standard' : 'Endless'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 520),
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(20, 20, 20, 8),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Mode description banner
+                        Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 14, vertical: 12),
+                          decoration: BoxDecoration(
+                            color: AppColors.stone.withValues(alpha: 0.4),
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(color: AppColors.stoneMid),
+                          ),
+                          child: Text(
+                            _isStandard
+                                ? '3 lives · fixed question count · earn stars'
+                                : 'No finish line · streak rewards · life recovery',
+                            style: tt.bodySmall?.copyWith(
+                              color: AppColors.textLight.withValues(alpha: 0.7),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 28),
+
+                        // ── Difficulty ──────────────────────────────────────
+                        Text('Difficulty',
+                            style: tt.labelLarge
+                                ?.copyWith(color: AppColors.parchment)),
+                        const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            const Text('🕯️',
+                                style: TextStyle(fontSize: 16)),
+                            Expanded(
+                              child: Slider(
+                                value: _difficultyBias.toDouble(),
+                                min: 1,
+                                max: 5,
+                                divisions: 4,
+                                activeColor: difficultyColor,
+                                inactiveColor:
+                                    AppColors.stoneMid.withValues(alpha: 0.5),
+                                onChanged: (v) => setState(
+                                    () => _difficultyBias = v.round()),
+                              ),
+                            ),
+                            const Text('⚔️',
+                                style: TextStyle(fontSize: 16)),
+                          ],
+                        ),
+                        Center(
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 14, vertical: 4),
+                            decoration: BoxDecoration(
+                              color: difficultyColor.withValues(alpha: 0.15),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(color: difficultyColor),
+                            ),
+                            child: Text(
+                              difficultyLabel,
+                              style: tt.labelMedium?.copyWith(
+                                  color: difficultyColor,
+                                  fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                        Text(
+                          description,
+                          style: tt.bodySmall?.copyWith(
+                              color:
+                                  AppColors.textLight.withValues(alpha: 0.6)),
+                          textAlign: TextAlign.center,
+                        ),
+
+                        // ── Question count (Standard only) ──────────────────
+                        if (_isStandard) ...[
+                          const SizedBox(height: 28),
+                          Text('Questions',
+                              style: tt.labelLarge
+                                  ?.copyWith(color: AppColors.parchment)),
+                          const SizedBox(height: 10),
+                          Row(
+                            children: QuizConfig.validCounts.map((n) {
+                              final active = n == _questionCount;
+                              return Padding(
+                                padding: const EdgeInsets.only(right: 10),
+                                child: GestureDetector(
+                                  onTap: () =>
+                                      setState(() => _questionCount = n),
+                                  child: Container(
+                                    width: 64,
+                                    height: 44,
+                                    alignment: Alignment.center,
+                                    decoration: BoxDecoration(
+                                      color: active
+                                          ? AppColors.torchAmber
+                                          : AppColors.stone,
+                                      borderRadius: BorderRadius.circular(6),
+                                      border: Border.all(
+                                          color: active
+                                              ? AppColors.torchAmber
+                                              : AppColors.stoneMid),
+                                    ),
+                                    child: Text(
+                                      '$n',
+                                      style: TextStyle(
+                                        color: active
+                                            ? AppColors.textDark
+                                            : AppColors.textLight,
+                                        fontWeight: FontWeight.bold,
+                                        fontSize: 16,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              );
+                            }).toList(),
+                          ),
+                        ],
+
+                        const SizedBox(height: 28),
+
+                        // ── Topics ──────────────────────────────────────────
+                        Text('Topics',
+                            style: tt.labelLarge
+                                ?.copyWith(color: AppColors.parchment)),
+                        const SizedBox(height: 8),
+                        Material(
+                          color: AppColors.stone,
+                          borderRadius: BorderRadius.circular(8),
+                          child: InkWell(
+                            borderRadius: BorderRadius.circular(8),
+                            onTap: _openTopics,
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 14),
+                              child: Row(
+                                children: [
+                                  const Icon(Icons.tune,
+                                      color: AppColors.torchAmber, size: 20),
+                                  const SizedBox(width: 12),
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          _allTopicsSelected
+                                              ? 'All topics'
+                                              : '$_topicCount of ${allTopicIds.length} topics',
+                                          style: const TextStyle(
+                                              color: AppColors.textLight),
+                                        ),
+                                        Text(
+                                          'Tap to customise',
+                                          style: tt.bodySmall?.copyWith(
+                                              color: AppColors.textLight
+                                                  .withValues(alpha: 0.5)),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                  const Icon(Icons.chevron_right,
+                                      color: AppColors.stoneMid),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 20),
+                      ],
+                    ),
+                  ),
+                ),
+
+                // ── Bottom action bar ────────────────────────────────────────
+                Container(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                  decoration: const BoxDecoration(
+                    color: AppColors.stoneDark,
+                    border:
+                        Border(top: BorderSide(color: AppColors.stoneMid)),
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: () => context.pop(),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: AppColors.textLight,
+                            side: const BorderSide(color: AppColors.stoneMid),
+                            padding:
+                                const EdgeInsets.symmetric(vertical: 14),
+                          ),
+                          child: const Text('Back'),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        flex: 2,
+                        child: ElevatedButton.icon(
+                          onPressed: _starting ? null : _startGame,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: _isStandard
+                                ? AppColors.torchAmber
+                                : AppColors.torchGold,
+                            foregroundColor: AppColors.textDark,
+                            padding:
+                                const EdgeInsets.symmetric(vertical: 14),
+                          ),
+                          icon: _starting
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      color: AppColors.textDark))
+                              : const Icon(Icons.play_arrow),
+                          label: Text(
+                            _starting ? 'Loading…' : 'Play',
+                            style: const TextStyle(
+                                fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/start/presentation/screens/mode_picker_screen.dart
+++ b/lib/features/start/presentation/screens/mode_picker_screen.dart
@@ -1,34 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/theme/app_theme.dart';
-import '../../../gameplay/data/topic_registry.dart';
 import '../../../gameplay/domain/models/quiz_config.dart';
-import '../../../gameplay/presentation/providers/game_state_provider.dart';
-import '../../../gameplay/presentation/providers/quiz_config_provider.dart';
 import '../../../settings/data/game_stats_repository.dart';
 
-class ModePickerScreen extends ConsumerStatefulWidget {
+class ModePickerScreen extends StatefulWidget {
   const ModePickerScreen({super.key});
 
   @override
-  ConsumerState<ModePickerScreen> createState() => _ModePickerScreenState();
+  State<ModePickerScreen> createState() => _ModePickerScreenState();
 }
 
-class _ModePickerScreenState extends ConsumerState<ModePickerScreen> {
-  int _difficultyBias = 3;
-  int _questionCount = 10;
+class _ModePickerScreenState extends State<ModePickerScreen> {
   int _endlessHighScore = 0;
-  bool _starting = false;
 
   @override
   void initState() {
     super.initState();
-    final config = ref.read(quizConfigProvider);
-    _difficultyBias = config.difficultyBias;
-    _questionCount = config.questionCount;
     _loadHighScore();
   }
 
@@ -37,54 +27,10 @@ class _ModePickerScreenState extends ConsumerState<ModePickerScreen> {
     if (mounted) setState(() => _endlessHighScore = stats.endlessHighScore);
   }
 
-  Future<void> _startGame(GameMode mode) async {
-    if (_starting) return;
-    setState(() => _starting = true);
-    final currentConfig = ref.read(quizConfigProvider);
-    final topicIds = currentConfig.selectedTopicIds.isEmpty
-        ? Set<String>.from(allTopicIds)
-        : currentConfig.selectedTopicIds;
-    final config = QuizConfig(
-      selectedTopicIds: topicIds,
-      questionCount: _questionCount,
-      gameMode: mode,
-      difficultyBias: _difficultyBias,
-    );
-    ref.read(quizConfigProvider.notifier).setConfig(config);
-    await ref.read(gameStateProvider.notifier).startGame(config);
-    if (mounted) context.go('/game');
-  }
-
-  void _openTopics(GameMode mode) {
-    final currentConfig = ref.read(quizConfigProvider);
-    ref.read(quizConfigProvider.notifier).setConfig(
-      currentConfig.copyWith(
-        gameMode: mode,
-        difficultyBias: _difficultyBias,
-        questionCount: _questionCount,
-      ),
-    );
-    context.push('/topics');
-  }
-
-  void _openSettings(GameMode mode) {
-    showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: AppColors.stoneDark,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (sheetCtx) => _ModeSettingsSheet(
-        mode: mode,
-        initialDifficultyBias: _difficultyBias,
-        initialQuestionCount: _questionCount,
-        onDifficultyChanged: (b) => setState(() => _difficultyBias = b),
-        onQuestionCountChanged: (c) => setState(() => _questionCount = c),
-        onChooseTopics: () {
-          Navigator.of(sheetCtx).pop();
-          _openTopics(mode);
-        },
-      ),
+  void _selectMode(GameMode mode) {
+    context.push(
+      '/game-settings',
+      extra: {'mode': mode},
     );
   }
 
@@ -115,9 +61,7 @@ class _ModePickerScreenState extends ConsumerState<ModePickerScreen> {
                       painter: const _DoorPainter(),
                       highlightColor: AppColors.torchAmber,
                       extraBadge: null,
-                      loading: _starting,
-                      onPlay: () => _startGame(GameMode.standard),
-                      onSettings: () => _openSettings(GameMode.standard),
+                      onSelect: () => _selectMode(GameMode.standard),
                     )
                         .animate()
                         .fadeIn(duration: 400.ms)
@@ -133,9 +77,7 @@ class _ModePickerScreenState extends ConsumerState<ModePickerScreen> {
                       extraBadge: _endlessHighScore > 0
                           ? 'Best: $_endlessHighScore pts'
                           : null,
-                      loading: _starting,
-                      onPlay: () => _startGame(GameMode.endless),
-                      onSettings: () => _openSettings(GameMode.endless),
+                      onSelect: () => _selectMode(GameMode.endless),
                     )
                         .animate()
                         .fadeIn(duration: 400.ms, delay: 150.ms)
@@ -161,9 +103,7 @@ class _ModeCard extends StatelessWidget {
   final CustomPainter painter;
   final Color highlightColor;
   final String? extraBadge;
-  final bool loading;
-  final VoidCallback onPlay;
-  final VoidCallback onSettings;
+  final VoidCallback onSelect;
 
   const _ModeCard({
     required this.title,
@@ -171,9 +111,7 @@ class _ModeCard extends StatelessWidget {
     required this.painter,
     required this.highlightColor,
     required this.extraBadge,
-    required this.loading,
-    required this.onPlay,
-    required this.onSettings,
+    required this.onSelect,
   });
 
   @override
@@ -185,288 +123,86 @@ class _ModeCard extends StatelessWidget {
       child: Stack(
         children: [
           Positioned.fill(child: CustomPaint(painter: painter)),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Illustration area
-              Expanded(
-                flex: 3,
-                child: Stack(
-                  alignment: Alignment.center,
-                  children: [
-                    // Settings gear (top-right)
-                    Positioned(
-                      top: 8,
-                      right: 8,
-                      child: Material(
-                        color: Colors.transparent,
-                        child: InkWell(
-                          borderRadius: BorderRadius.circular(20),
-                          onTap: onSettings,
-                          child: Container(
-                            padding: const EdgeInsets.all(8),
-                            decoration: BoxDecoration(
-                              color: AppColors.stoneDark.withValues(alpha: 0.7),
-                              shape: BoxShape.circle,
-                            ),
-                            child: Icon(
-                              Icons.settings_outlined,
-                              size: 20,
-                              color: AppColors.textLight.withValues(alpha: 0.8),
+          InkWell(
+            onTap: onSelect,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Illustration area
+                const Expanded(flex: 3, child: SizedBox.shrink()),
+                // Bottom info + select button
+                Container(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                  color: AppColors.stoneDark.withValues(alpha: 0.88),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Text(
+                            title,
+                            style: tt.titleLarge?.copyWith(
+                              color: AppColors.textLight,
+                              fontWeight: FontWeight.bold,
                             ),
                           ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              // Bottom info + play button
-              Container(
-                padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-                color: AppColors.stoneDark.withValues(alpha: 0.88),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Text(
-                          title,
-                          style: tt.titleLarge?.copyWith(
-                            color: AppColors.textLight,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        if (extraBadge != null) ...[
-                          const SizedBox(width: 8),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 8, vertical: 2),
-                            decoration: BoxDecoration(
-                              color: AppColors.torchGold.withValues(alpha: 0.15),
-                              borderRadius: BorderRadius.circular(12),
-                              border: Border.all(
-                                  color: AppColors.torchGold, width: 1),
-                            ),
-                            child: Text(
-                              extraBadge!,
-                              style: tt.labelSmall?.copyWith(
-                                color: AppColors.torchGold,
-                                fontWeight: FontWeight.w600,
+                          if (extraBadge != null) ...[
+                            const SizedBox(width: 8),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 8, vertical: 2),
+                              decoration: BoxDecoration(
+                                color:
+                                    AppColors.torchGold.withValues(alpha: 0.15),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                    color: AppColors.torchGold, width: 1),
+                              ),
+                              child: Text(
+                                extraBadge!,
+                                style: tt.labelSmall?.copyWith(
+                                  color: AppColors.torchGold,
+                                  fontWeight: FontWeight.w600,
+                                ),
                               ),
                             ),
-                          ),
+                          ],
                         ],
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      subtitle,
-                      style: tt.bodySmall?.copyWith(
-                        color: AppColors.textLight.withValues(alpha: 0.6),
                       ),
-                    ),
-                    const SizedBox(height: 12),
-                    SizedBox(
-                      width: double.infinity,
-                      child: ElevatedButton(
-                        onPressed: loading ? null : onPlay,
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: highlightColor,
-                          foregroundColor: AppColors.textDark,
-                          padding: const EdgeInsets.symmetric(vertical: 12),
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(6)),
+                      const SizedBox(height: 4),
+                      Text(
+                        subtitle,
+                        style: tt.bodySmall?.copyWith(
+                          color: AppColors.textLight.withValues(alpha: 0.6),
                         ),
-                        child: loading
-                            ? const SizedBox(
-                                height: 20,
-                                width: 20,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2.5,
-                                  color: AppColors.textDark,
-                                ),
-                              )
-                            : Text(
-                                'Play',
-                                style: tt.labelLarge?.copyWith(
-                                  color: AppColors.textDark,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
                       ),
-                    ),
-                  ],
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          onPressed: onSelect,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: highlightColor,
+                            foregroundColor: AppColors.textDark,
+                            padding:
+                                const EdgeInsets.symmetric(vertical: 12),
+                            shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(6)),
+                          ),
+                          child: Text(
+                            'Select',
+                            style: tt.labelLarge?.copyWith(
+                              color: AppColors.textDark,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Settings bottom sheet
-// ---------------------------------------------------------------------------
-
-class _ModeSettingsSheet extends StatefulWidget {
-  final GameMode mode;
-  final int initialDifficultyBias;
-  final int initialQuestionCount;
-  final void Function(int) onDifficultyChanged;
-  final void Function(int) onQuestionCountChanged;
-  final VoidCallback onChooseTopics;
-
-  const _ModeSettingsSheet({
-    required this.mode,
-    required this.initialDifficultyBias,
-    required this.initialQuestionCount,
-    required this.onDifficultyChanged,
-    required this.onQuestionCountChanged,
-    required this.onChooseTopics,
-  });
-
-  @override
-  State<_ModeSettingsSheet> createState() => _ModeSettingsSheetState();
-}
-
-class _ModeSettingsSheetState extends State<_ModeSettingsSheet> {
-  late int _difficultyBias;
-  late int _questionCount;
-
-  @override
-  void initState() {
-    super.initState();
-    _difficultyBias = widget.initialDifficultyBias;
-    _questionCount = widget.initialQuestionCount;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final tt = Theme.of(context).textTheme;
-    final isStandard = widget.mode == GameMode.standard;
-
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 20, 20, 40),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            '${isStandard ? "Standard" : "Endless"} Settings',
-            style: tt.titleMedium?.copyWith(color: AppColors.textLight),
-          ),
-          const SizedBox(height: 20),
-
-          // Difficulty
-          Text('Difficulty',
-              style: tt.labelMedium?.copyWith(color: AppColors.parchment)),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              const Text('🕯️', style: TextStyle(fontSize: 14)),
-              const SizedBox(width: 8),
-              ...List.generate(5, (i) {
-                final value = i + 1;
-                final active = value == _difficultyBias;
-                final color = _biasColor(value);
-                return Padding(
-                  padding: const EdgeInsets.only(right: 8),
-                  child: GestureDetector(
-                    onTap: () {
-                      setState(() => _difficultyBias = value);
-                      widget.onDifficultyChanged(value);
-                    },
-                    child: Container(
-                      width: 40,
-                      height: 40,
-                      alignment: Alignment.center,
-                      decoration: BoxDecoration(
-                        color: active ? color : AppColors.stone,
-                        borderRadius: BorderRadius.circular(6),
-                        border: Border.all(
-                            color: active ? color : AppColors.stoneMid),
-                      ),
-                      child: Text(
-                        '$value',
-                        style: TextStyle(
-                          color: active ? Colors.white : AppColors.textLight,
-                          fontWeight:
-                              active ? FontWeight.bold : FontWeight.normal,
-                        ),
-                      ),
-                    ),
-                  ),
-                );
-              }),
-              const SizedBox(width: 4),
-              const Text('⚔️', style: TextStyle(fontSize: 14)),
-            ],
-          ),
-
-          // Question count (Standard only)
-          if (isStandard) ...[
-            const SizedBox(height: 20),
-            Text('Questions',
-                style: tt.labelMedium?.copyWith(color: AppColors.parchment)),
-            const SizedBox(height: 8),
-            Row(
-              children: [5, 10, 20].map((n) {
-                final active = n == _questionCount;
-                return Padding(
-                  padding: const EdgeInsets.only(right: 8),
-                  child: GestureDetector(
-                    onTap: () {
-                      setState(() => _questionCount = n);
-                      widget.onQuestionCountChanged(n);
-                    },
-                    child: Container(
-                      width: 52,
-                      height: 40,
-                      alignment: Alignment.center,
-                      decoration: BoxDecoration(
-                        color: active ? AppColors.torchAmber : AppColors.stone,
-                        borderRadius: BorderRadius.circular(6),
-                        border: Border.all(
-                          color: active
-                              ? AppColors.torchAmber
-                              : AppColors.stoneMid,
-                        ),
-                      ),
-                      child: Text(
-                        '$n',
-                        style: TextStyle(
-                          color: active
-                              ? AppColors.textDark
-                              : AppColors.textLight,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                  ),
-                );
-              }).toList(),
+              ],
             ),
-          ],
-
-          const SizedBox(height: 20),
-
-          // Choose Topics
-          ListTile(
-            contentPadding: EdgeInsets.zero,
-            leading: const Icon(Icons.tune, color: AppColors.torchAmber),
-            title: const Text('Choose Topics',
-                style: TextStyle(color: AppColors.textLight)),
-            subtitle: Text(
-              'Select which topics to include',
-              style: tt.bodySmall?.copyWith(
-                  color: AppColors.textLight.withValues(alpha: 0.5)),
-            ),
-            trailing:
-                const Icon(Icons.chevron_right, color: AppColors.stoneMid),
-            onTap: widget.onChooseTopics,
           ),
         ],
       ),
@@ -477,12 +213,6 @@ class _ModeSettingsSheetState extends State<_ModeSettingsSheet> {
 // ---------------------------------------------------------------------------
 // Painters
 // ---------------------------------------------------------------------------
-
-Color _biasColor(int bias) => switch (bias) {
-      1 || 2 => AppColors.torchGold,
-      4 || 5 => AppColors.dangerRed,
-      _ => AppColors.torchAmber,
-    };
 
 /// Stone arch door — Standard mode illustration.
 class _DoorPainter extends CustomPainter {

--- a/lib/features/start/presentation/screens/topic_picker_screen.dart
+++ b/lib/features/start/presentation/screens/topic_picker_screen.dart
@@ -13,7 +13,12 @@ import '../../../gameplay/presentation/providers/quiz_config_provider.dart';
 import '../../../settings/data/game_stats_repository.dart';
 
 class TopicPickerScreen extends ConsumerStatefulWidget {
-  const TopicPickerScreen({super.key});
+  /// When true the screen is navigated to from GameSettingsScreen.
+  /// The full start-game bottom bar is replaced with "Set All" / "Set Chosen"
+  /// buttons that commit the selection back to [quizConfigProvider] and pop.
+  final bool fromSettings;
+
+  const TopicPickerScreen({super.key, this.fromSettings = false});
 
   @override
   ConsumerState<TopicPickerScreen> createState() => _TopicPickerScreenState();
@@ -90,6 +95,24 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
 
   void _selectAll() => setState(() => _selected = Set.from(allTopicIds));
   void _clearAll() => setState(() => _selected.clear());
+
+  void _onSetAll() {
+    final all = Set<String>.from(allTopicIds);
+    setState(() => _selected = all);
+    final config = ref.read(quizConfigProvider);
+    ref.read(quizConfigProvider.notifier).setConfig(
+          config.copyWith(selectedTopicIds: all),
+        );
+    context.pop();
+  }
+
+  void _onSetChosen() {
+    final config = ref.read(quizConfigProvider);
+    ref.read(quizConfigProvider.notifier).setConfig(
+          config.copyWith(selectedTopicIds: Set.from(_selected)),
+        );
+    context.pop();
+  }
 
   Future<void> _startGame() async {
     setState(() => _starting = true);
@@ -168,20 +191,28 @@ class _TopicPickerScreenState extends ConsumerState<TopicPickerScreen> {
             ),
           ),
 
-          // Bottom bar
-          _BottomBar(
-            questionCount: _questionCount,
-            availableQuestions: _availableQuestions,
-            gameMode: _gameMode,
-            difficultyBias: _difficultyBias,
-            canStart: _canStart,
-            starting: _starting,
-            endlessHighScore: _endlessHighScore,
-            onCountChanged: (c) => setState(() => _questionCount = c),
-            onModeChanged: (m) => setState(() => _gameMode = m),
-            onDifficultyChanged: (b) => setState(() => _difficultyBias = b),
-            onStart: _startGame,
-          ),
+          // Bottom bar — set-topics mode when launched from GameSettingsScreen
+          if (widget.fromSettings)
+            _SetTopicsBar(
+              selectedCount: _selected.length,
+              totalCount: allTopicIds.length,
+              onSetAll: _onSetAll,
+              onSetChosen: _onSetChosen,
+            )
+          else
+            _BottomBar(
+              questionCount: _questionCount,
+              availableQuestions: _availableQuestions,
+              gameMode: _gameMode,
+              difficultyBias: _difficultyBias,
+              canStart: _canStart,
+              starting: _starting,
+              endlessHighScore: _endlessHighScore,
+              onCountChanged: (c) => setState(() => _questionCount = c),
+              onModeChanged: (m) => setState(() => _gameMode = m),
+              onDifficultyChanged: (b) => setState(() => _difficultyBias = b),
+              onStart: _startGame,
+            ),
         ],
       ),
     );
@@ -387,6 +418,82 @@ class _CategoryTile extends StatelessWidget {
           }).toList(),
         ),
       ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Set Topics Bar (used when fromSettings == true)
+// ---------------------------------------------------------------------------
+
+class _SetTopicsBar extends StatelessWidget {
+  final int selectedCount;
+  final int totalCount;
+  final VoidCallback onSetAll;
+  final VoidCallback onSetChosen;
+
+  const _SetTopicsBar({
+    required this.selectedCount,
+    required this.totalCount,
+    required this.onSetAll,
+    required this.onSetChosen,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    final allSelected = selectedCount == totalCount;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+      decoration: const BoxDecoration(
+        color: AppColors.stoneDark,
+        border: Border(top: BorderSide(color: AppColors.stoneMid)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            allSelected
+                ? 'All $totalCount topics selected'
+                : '$selectedCount of $totalCount topics selected',
+            style: tt.labelSmall?.copyWith(
+                color: AppColors.textLight.withValues(alpha: 0.55)),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: onSetAll,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: AppColors.textLight,
+                    side: const BorderSide(color: AppColors.stoneMid),
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  child: const Text('Set All'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                flex: 2,
+                child: ElevatedButton(
+                  onPressed: selectedCount > 0 ? onSetChosen : null,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.torchAmber,
+                    foregroundColor: AppColors.textDark,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  child: const Text(
+                    'Set Chosen',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -316,10 +316,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "48fb2f42ad057476fa4b733cb95e9f9ea7b0b010bb349ea491dca7dbdb18ffc4"
+      sha256: "5540e4a3f416dd4a93458257b908eb88353cbd0fb5b0a3d1bd7d849ba1e88735"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.0"
+    version: "17.2.1"
   google_fonts:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -250,10 +250,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "6.0.0"
   flutter_markdown:
     dependency: "direct main"
     description:
@@ -412,10 +412,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "6.1.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^3.3.1
   riverpod_annotation: ^4.0.2
-  go_router: ^17.2.0
+  go_router: ^17.2.1
   webview_flutter: ^4.7.0
   webview_flutter_android: ^4.11.0
   google_fonts: ^8.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.13.1
   riverpod_generator: ^4.0.3
-  flutter_lints: ^3.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true

--- a/release_notes.md
+++ b/release_notes.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - Bug report drafts can now be saved, listed in the Pending tab, and reloaded into the Bug Report form — the tab was missing a Save Draft button and draft restore logic entirely (#110)
+- Issues tab no longer shows the "🔗 PR open" badge on issues that are only casually mentioned in a PR body — the detection regex now requires an explicit closing keyword (Closes/Fixes/Resolves) (#114)
 
 ### Content
 - (none)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,10 +3,12 @@
 ## Unreleased
 
 ### Features
-- (none)
+- Dedicated **Game Settings** screen between mode selection and game start — shows a difficulty slider (Very Easy → Very Hard) with a contextual description (Endless mode shows the streak-reward threshold), question-count buttons for Standard mode, and a Topics tile; mode cards now show a **Select** button instead of launching immediately (#112)
+- Topic picker launched from Game Settings shows **Set All** / **Set Chosen** confirmation buttons instead of the full start bar, making it clear the selection returns to the settings page (#112)
+- **Question Bank** nav tile added to the Learn section of Settings (#112)
 
 ### Fixes
-- (none)
+- Bug report drafts can now be saved, listed in the Pending tab, and reloaded into the Bug Report form — the tab was missing a Save Draft button and draft restore logic entirely (#110)
 
 ### Content
 - (none)

--- a/scripts/setup_flutter.sh
+++ b/scripts/setup_flutter.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Ensures Flutter FLUTTER_VERSION is available at /opt/flutter on Linux.
+# Safe to run repeatedly — exits early if the correct version is already present.
+# Runs automatically via the SessionStart hook in .claude/settings.json.
+
+set -euo pipefail
+
+FLUTTER_VERSION="3.41.6"
+FLUTTER_DIR="/opt/flutter"
+FLUTTER_BIN="$FLUTTER_DIR/bin/flutter"
+
+is_correct_version() {
+  "$FLUTTER_BIN" --version --suppress-analytics 2>/dev/null \
+    | grep -q "Flutter $FLUTTER_VERSION"
+}
+
+if [ -f "$FLUTTER_BIN" ] && is_correct_version; then
+  echo "Flutter $FLUTTER_VERSION already installed at $FLUTTER_DIR"
+else
+  echo "Flutter $FLUTTER_VERSION not found — installing..."
+  ARCHIVE="flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+  URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/$ARCHIVE"
+  TMP="/tmp/$ARCHIVE"
+
+  echo "Downloading $URL ..."
+  curl -fSL "$URL" -o "$TMP"
+
+  echo "Extracting to /opt/ ..."
+  rm -rf "$FLUTTER_DIR"
+  tar xf "$TMP" -C /opt/
+  rm -f "$TMP"
+
+  echo "Flutter $FLUTTER_VERSION installed."
+fi
+
+# Allow git operations inside the SDK when running as root.
+git config --global --add safe.directory "$FLUTTER_DIR" 2>/dev/null || true
+
+echo "Running flutter pub get..."
+"$FLUTTER_BIN" pub get
+echo "Flutter ready."

--- a/test/features/feedback/bug_report_draft_test.dart
+++ b/test/features/feedback/bug_report_draft_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:mind_mazeish/features/feedback/data/feedback_draft_repository.dart';
+import 'package:mind_maze/features/feedback/data/feedback_draft_repository.dart';
 
 // Regression test for sai-pher/Mind-mazeish#110
 //

--- a/test/features/feedback/bug_report_draft_test.dart
+++ b/test/features/feedback/bug_report_draft_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mind_mazeish/features/feedback/data/feedback_draft_repository.dart';
+
+// Regression test for sai-pher/Mind-mazeish#110
+//
+// Root cause: _BugReportTab had no Save Draft button, no loadedDraft prop, and
+// no didUpdateWidget() restore logic. FeedbackDraft also lacked field-name
+// constants for the six bug-report fields.
+//
+// Fix: added fieldGiven/fieldWhen/fieldThenExpected/fieldButActually/
+// fieldSupportingDetails constants and wired _BugReportTab identically to the
+// General and Content tabs.
+
+void main() {
+  group('FeedbackDraft — bug type', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('bug draft round-trips all six fields through the repository',
+        () async {
+      final repo = FeedbackDraftRepository();
+      final draft = FeedbackDraft(
+        id: '1',
+        type: 'bug',
+        fields: {
+          FeedbackDraft.fieldTitle:            'App crashes on results',
+          FeedbackDraft.fieldGiven:            'A game has just finished',
+          FeedbackDraft.fieldWhen:             'User taps Continue',
+          FeedbackDraft.fieldThenExpected:     'Results screen is shown',
+          FeedbackDraft.fieldButActually:      'App closes silently',
+          FeedbackDraft.fieldSupportingDetails: 'Reproducible on Pixel 9',
+        },
+        createdAt: DateTime(2026, 4, 20),
+        updatedAt: DateTime(2026, 4, 20),
+      );
+
+      await repo.save(draft);
+      final loaded = await repo.loadAll();
+
+      expect(loaded, hasLength(1));
+      final r = loaded.first;
+      expect(r.type, equals('bug'));
+      expect(r.fields[FeedbackDraft.fieldTitle],            'App crashes on results');
+      expect(r.fields[FeedbackDraft.fieldGiven],            'A game has just finished');
+      expect(r.fields[FeedbackDraft.fieldWhen],             'User taps Continue');
+      expect(r.fields[FeedbackDraft.fieldThenExpected],     'Results screen is shown');
+      expect(r.fields[FeedbackDraft.fieldButActually],      'App closes silently');
+      expect(r.fields[FeedbackDraft.fieldSupportingDetails], 'Reproducible on Pixel 9');
+    });
+
+    test('displayTitle returns the title field for a bug draft', () {
+      final draft = FeedbackDraft(
+        id: '2',
+        type: 'bug',
+        fields: {FeedbackDraft.fieldTitle: 'Crash on launch'},
+        createdAt: DateTime(2026, 4, 20),
+        updatedAt: DateTime(2026, 4, 20),
+      );
+      expect(draft.displayTitle, equals('Crash on launch'));
+    });
+
+    test('displayTitle falls back to (no title) when title field is absent', () {
+      final draft = FeedbackDraft(
+        id: '3',
+        type: 'bug',
+        fields: {},
+        createdAt: DateTime(2026, 4, 20),
+        updatedAt: DateTime(2026, 4, 20),
+      );
+      expect(draft.displayTitle, equals('(no title)'));
+    });
+
+    test('deleting a bug draft removes it from the repository', () async {
+      final repo = FeedbackDraftRepository();
+      final draft = FeedbackDraft(
+        id: '42',
+        type: 'bug',
+        fields: {FeedbackDraft.fieldTitle: 'Delete me'},
+        createdAt: DateTime(2026, 4, 20),
+        updatedAt: DateTime(2026, 4, 20),
+      );
+
+      await repo.save(draft);
+      await repo.delete('42');
+      final remaining = await repo.loadAll();
+
+      expect(remaining, isEmpty);
+    });
+  });
+}

--- a/test/features/feedback/pr_label_regex_test.dart
+++ b/test/features/feedback/pr_label_regex_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+
+// Regression test for sai-pher/Mind-mazeish#114
+//
+// Root cause: the PR-reference regex in fetchIssueNumbersWithOpenPr() included
+// a bare '#' alternative — RegExp(r'(?:closes?|fixes?|resolves?|#)\s*#?(\d+)')
+// — which matched ANY '#N' mention in a PR body (e.g. "see #76", "relates to
+// #91"), flagging issues as having an open PR even when none exists.
+//
+// Fix: removed the bare '#' branch; pattern now requires an explicit closing
+// keyword: RegExp(r'(?:closes?|fixes?|resolves?)\s+#(\d+)')
+
+final _pattern =
+    RegExp(r'(?:closes?|fixes?|resolves?)\s+#(\d+)', caseSensitive: false);
+
+Set<int> _extract(String text) => _pattern
+    .allMatches(text)
+    .map((m) => int.tryParse(m.group(1)!))
+    .whereType<int>()
+    .toSet();
+
+void main() {
+  group('PR closing-keyword pattern', () {
+    test('matches Closes #N', () {
+      expect(_extract('Closes #110'), equals({110}));
+    });
+
+    test('matches Close #N (without s)', () {
+      expect(_extract('Close #110'), equals({110}));
+    });
+
+    test('matches Fixes #N', () {
+      expect(_extract('Fixes #42'), equals({42}));
+    });
+
+    test('matches Fix #N', () {
+      expect(_extract('Fix #42'), equals({42}));
+    });
+
+    test('matches Resolves #N', () {
+      expect(_extract('Resolves #7'), equals({7}));
+    });
+
+    test('matches Resolve #N', () {
+      expect(_extract('Resolve #7'), equals({7}));
+    });
+
+    test('is case-insensitive', () {
+      expect(_extract('CLOSES #99'), equals({99}));
+      expect(_extract('fixes #99'), equals({99}));
+    });
+
+    test('extracts multiple closing references from a PR body', () {
+      const body = '''
+Closes #110
+Closes #112
+
+Some additional context.
+''';
+      expect(_extract(body), equals({110, 112}));
+    });
+
+    test('does NOT match bare #N references — the bug', () {
+      expect(_extract('See #76 for background'), isEmpty);
+      expect(_extract('Related to #91, #94'), isEmpty);
+      expect(_extract('Investigated in #107'), isEmpty);
+    });
+
+    test('does NOT match #N when preceded by non-keyword text', () {
+      expect(_extract('issue #76'), isEmpty);
+      expect(_extract('PR #113'), isEmpty);
+    });
+
+    test('does not double-count when body mixes closing and casual mentions', () {
+      const body = 'Closes #110\nSee also #76 and #91 for background.';
+      expect(_extract(body), equals({110}));
+    });
+  });
+}

--- a/test/features/feedback/pr_label_regex_test.dart
+++ b/test/features/feedback/pr_label_regex_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 // keyword: RegExp(r'(?:closes?|fixes?|resolves?)\s+#(\d+)')
 
 final _pattern =
-    RegExp(r'(?:closes?|fixes?|resolves?)\s+#(\d+)', caseSensitive: false);
+    RegExp(r'(?:closes?|fix(?:es)?|resolves?)\s+#(\d+)', caseSensitive: false);
 
 Set<int> _extract(String text) => _pattern
     .allMatches(text)


### PR DESCRIPTION
Closes #110
Closes #112
Closes #114

## Summary

- **#110 — Bug report drafts**: `_BugReportTab` was the only feedback tab never wired to the draft system. Added a Save Draft button, `_saveDraft()` / `didUpdateWidget()` restore logic, five new `FeedbackDraft` field-name constants for the structured bug fields, routing of `'bug'` drafts to tab 1 in `_loadDraft()`, and a `'🐛 Bug Report'` label in the Pending tab.

- **#112 — Game mode settings flow**: Mode cards now show a **Select** button that navigates to a new `GameSettingsScreen` before starting. The settings screen has a difficulty slider (Very Easy → Very Hard) with a contextual description (Endless shows the streak-reward threshold), question-count buttons for Standard mode, and a Topics tile. `TopicPickerScreen` gains a `fromSettings` mode with **Set All** / **Set Chosen** confirmation buttons. A **Question Bank** nav tile was added to the Learn section of Settings.

- **#114 — PR open badge false positives**: The regex in `fetchIssueNumbersWithOpenPr()` included a bare `#` branch that matched any `#N` mention in a PR body (e.g. "see #76"), incorrectly flagging those issues as having an open PR. Removed the bare `#` alternative; pattern now requires an explicit closing keyword (Closes/Fixes/Resolves).

## Test plan
- [ ] `flutter analyze --fatal-infos` passes
- [ ] `flutter test` passes (regression tests: `bug_report_draft_test.dart`, `pr_label_regex_test.dart`)
- [ ] **#110 manual**: Feedback → Bug Report → fill fields → Save Draft → Pending tab shows "🐛 Bug Report" → tap to reload all 6 fields
- [ ] **#112 manual**: Select Mode → Select on a card → Game Settings screen appears → adjust difficulty slider → Topics → Set Chosen → Play → game starts; Settings → Learn → Question Bank navigates to `/stats`
- [ ] **#114 manual**: Issues tab — only issues with a genuinely open PR (currently #110, #112, #114 via PR #113) show the "🔗 PR open" badge; #76, #91, #94, #107 no longer show it

https://claude.ai/code/session_01XdKkrSFycTyMsmQ5w3vhvk