### PR TITLE
feat: Maze Mode — core game plan (#40)

### DIFF
--- a/ai/tasks/maze-mode/plan.md
+++ b/ai/tasks/maze-mode/plan.md
@@ -1,0 +1,148 @@
+# Plan: Maze Mode (Core Game)
+
+## Context
+Issue #40 requests a maze navigation element in Mind Mazeish, mirroring the original Mind Maze game. The owner has specified a 10×10 grid layout, hidden Throne Room, fog-of-war reveal, answer-to-unlock doors, skip-to-pass, and free backtracking. XP / reward systems are explicitly out of scope for this iteration. The feature is additive — existing standard/endless modes are untouched.
+
+---
+
+## Data Models (`lib/features/maze/domain/models/`)
+
+| Model | Purpose |
+|-------|---------|
+| `MazePosition` | `(x, y)` coordinate on 10×10 grid |
+| `DoorState` enum | `wall / locked / open / skipped` — per connection |
+| `RoomStatus` enum | `hidden / visible / visited / answered / skipped` — per room |
+| `MazeRoom` | Cell: position, questionId, isThroneRoom, status, answeredCorrectly |
+| `MazeStatus` enum | `loading / navigating / questionActive / answerRevealed / complete / gameOver` |
+| `MazeState` | Full state: grid, connections map, playerPosition, thronePosition, questions, lives, status |
+
+All immutable, pure Dart, `copyWith` pattern. See `proposal/01-maze-state-model.md`.
+
+---
+
+## Maze Generation (`lib/features/maze/data/maze_generator.dart`)
+
+- **Algorithm**: Recursive backtracker DFS (perfect maze — one path between any two cells)
+- **Grid**: 10×10, player starts at `(0,0)`, Throne Room at maximum BFS distance from start
+- **Questions**: One `QuizQuestion` per non-start, non-throne cell; drawn from `selectQuestionsFrom(config)`; cycles if pool < 98
+- **Fog of war**: Derived from `RoomStatus` at render time — not stored in state
+- **Pure function**: `MazeGenerator.generate(config, questionPool, seed)` → `MazeState`
+
+See `proposal/02-maze-generation.md`.
+
+---
+
+## State Provider (`lib/features/maze/presentation/providers/maze_state_provider.dart`)
+
+```
+MazeStateNotifier extends Notifier<MazeState?>
+  startMaze(QuizConfig)       — generate + load questions → MazeState
+  movePlayer(Direction)       — validate connection, update position, open question if needed
+  submitAnswer(int index)     — check correctness, update room/connection, decrement lives if wrong
+  skipRoom()                  — mark room skipped, connection skipped, stay navigating
+  dismissFunFact()            — answerRevealed → navigating
+  restart()                   — null state
+
+enum Direction { north, south, east, west }
+```
+
+---
+
+## Screens & Widgets
+
+| File | Purpose |
+|------|---------|
+| `MazeSettingsScreen` | Topic + difficulty picker; "Enter the Maze" CTA |
+| `MazeScreen` | Main screen: map + action panel |
+| `MazeMapWidget` | 10×10 grid; fog of war; player position |
+| `MazeCellWidget` | Single cell: status-driven appearance |
+| `MazeActionPanel` | Direction arrows, lives, contextual room buttons |
+| Question bottom sheet | Reuse `AnswerButton` + `QuestionCard` widgets from gameplay |
+
+See `proposal/03-maze-ui.md` for visual spec.
+
+---
+
+## Routing
+
+| Route | Screen | Notes |
+|-------|--------|-------|
+| `/maze-settings` | MazeSettingsScreen | Entry from StartScreen |
+| `/maze` | MazeScreen | Replaces `/game` for maze flow |
+
+Results navigate to existing `/results` with maze-specific extras.
+
+---
+
+## Entry Point
+
+Add "Maze Mode" tile on `StartScreen` alongside existing "Play" / "Endless" tiles.
+
+---
+
+## Order of Operations
+
+1. **Branch**: create `feat/issue-40-put-maze-in-mind-mazeish` from `main`
+2. **Domain models**: `MazePosition`, `DoorState`, `RoomStatus`, `MazeRoom`, `MazeStatus`, `MazeState` — pure Dart, no Flutter
+3. **Unit tests**: `test/features/maze/domain/maze_state_test.dart` — state transitions, lives, win/lose
+4. **Maze generator**: `MazeGenerator.generate()` — DFS, throne placement, question assignment
+5. **Generator tests**: `test/features/maze/data/maze_generator_test.dart` — connectivity, throne placement, 99 connections
+6. **State provider**: `MazeStateNotifier` — `startMaze`, `movePlayer`, `submitAnswer`, `skipRoom`, `dismissFunFact`
+7. **Routing**: add `/maze-settings` and `/maze` to `lib/app.dart`
+8. **MazeSettingsScreen**: topic + difficulty picker reusing existing components
+9. **MazeMapWidget + MazeCellWidget**: grid render, fog of war, player icon
+10. **MazeActionPanel**: direction arrows, lives display, room context buttons
+11. **MazeScreen**: compose map + action panel + question bottom sheet
+12. **StartScreen**: add Maze Mode entry tile
+13. **Results integration**: pass maze summary to ResultsScreen
+14. **flutter analyze + flutter test**: zero errors
+15. **Release notes**: run `release-notes` skill, commit
+16. **Push + PR**: target `main`
+
+---
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `lib/features/maze/domain/models/maze_position.dart` | Create |
+| `lib/features/maze/domain/models/door_state.dart` | Create |
+| `lib/features/maze/domain/models/room_status.dart` | Create |
+| `lib/features/maze/domain/models/maze_room.dart` | Create |
+| `lib/features/maze/domain/models/maze_status.dart` | Create |
+| `lib/features/maze/domain/models/maze_state.dart` | Create |
+| `lib/features/maze/data/maze_generator.dart` | Create |
+| `lib/features/maze/presentation/providers/maze_state_provider.dart` | Create |
+| `lib/features/maze/presentation/screens/maze_settings_screen.dart` | Create |
+| `lib/features/maze/presentation/screens/maze_screen.dart` | Create |
+| `lib/features/maze/presentation/widgets/maze_map_widget.dart` | Create |
+| `lib/features/maze/presentation/widgets/maze_cell_widget.dart` | Create |
+| `lib/features/maze/presentation/widgets/maze_action_panel.dart` | Create |
+| `lib/app.dart` | Modify — add `/maze-settings`, `/maze` routes |
+| `lib/features/start/presentation/screens/start_screen.dart` | Modify — add Maze Mode tile |
+| `test/features/maze/domain/maze_state_test.dart` | Create |
+| `test/features/maze/data/maze_generator_test.dart` | Create |
+| `release_notes.md` | Modify (release-notes skill) |
+
+---
+
+## Verification
+
+```bash
+export PATH="$PATH:/opt/flutter/bin"
+flutter analyze --fatal-infos
+flutter test --reporter expanded
+# Expected: 0 errors, 0 warnings; all maze tests pass
+```
+
+Manual smoke test on device:
+1. Start → Maze Mode → pick topic → Enter the Maze
+2. Fog of war visible on initial render (only start cell + neighbours shown)
+3. Move N/S/E/W — walls block invalid moves
+4. Enter room → question sheet appears
+5. Answer correctly → cell turns gold, door opens
+6. Answer wrong → life lost; red flash; can retry or skip
+7. Skip → cell muted amber, door stays "skipped"
+8. Backtrack through visited rooms freely
+9. Reach Throne Room → complete screen
+10. Lives reach 0 → game over screen

--- a/ai/tasks/maze-mode/proposal/01-maze-state-model.md
+++ b/ai/tasks/maze-mode/proposal/01-maze-state-model.md
@@ -1,0 +1,135 @@
+# Proposal 01: Maze State Model
+
+## Design goals
+- Pure Dart domain objects, no Flutter imports
+- Immutable with `copyWith`
+- No dependency on existing `GameState` (separate concern)
+- Reuses `QuizQuestion`, `QuizConfig`, `Question` as-is
+
+---
+
+## Core types
+
+### `MazePosition`
+```dart
+class MazePosition {
+  final int x; // 0–9 column
+  final int y; // 0–9 row
+}
+```
+
+### `DoorState`
+```dart
+enum DoorState {
+  wall,      // no connection between cells
+  locked,    // connected but question not yet answered
+  open,      // answered correctly
+  skipped,   // player passed through without answering
+}
+```
+Doors belong to **connections**, not rooms. A connection is an edge `(pos, direction)`.
+
+### `RoomStatus`
+```dart
+enum RoomStatus {
+  hidden,    // fog of war — not yet visible
+  visible,   // adjacent to a visited room, shown on map but not entered
+  visited,   // entered; question not answered (or no question)
+  answered,  // question answered correctly
+  skipped,   // question skipped
+}
+```
+
+### `MazeRoom`
+```dart
+class MazeRoom {
+  final MazePosition position;
+  final String? questionId;       // null if this cell is a plain passage
+  final bool isThroneRoom;
+  final RoomStatus status;
+  final bool? answeredCorrectly;  // null until attempt
+}
+```
+
+### `MazeStatus`
+```dart
+enum MazeStatus {
+  loading,
+  navigating,      // player choosing a direction
+  questionActive,  // question sheet open for current room
+  answerRevealed,  // after answering, showing fun fact
+  complete,        // player reached throne room
+  gameOver,        // lives exhausted
+}
+```
+
+### `MazeState`
+```dart
+class MazeState {
+  // Grid: grid[y][x] — row-major
+  final List<List<MazeRoom>> grid;               // 10×10
+
+  // Connections: key = "$x1,$y1-$x2,$y2" (smaller coords first)
+  final Map<String, DoorState> connections;
+
+  final MazePosition playerPosition;
+  final MazePosition thronePosition;  // used for win detection; hidden on map until discovered
+  final bool throneDiscovered;        // true once player enters adjacent cell
+
+  final Map<String, QuizQuestion> questions; // questionId → QuizQuestion
+
+  final int lives;                    // starts at 3
+  final MazeStatus status;
+  final QuizConfig config;
+  final QuizQuestion? activeQuestion; // non-null during questionActive/answerRevealed
+  final bool? lastAnswerCorrect;
+}
+```
+
+---
+
+## Connection key convention
+For adjacent positions `a` and `b`, sort by `(y, x)` ascending then join:
+`"${a.y},${a.x}-${b.y},${b.x}"` where `a` always < `b`.
+
+---
+
+## State transitions
+
+```
+loading
+  └─► navigating             (maze generated)
+
+navigating
+  ├─► navigating             (move to room with no question / already answered / skipped)
+  ├─► questionActive         (enter unvisited room that has a question)
+  └─► complete               (enter throne room)
+
+questionActive
+  └─► answerRevealed         (player submits answer)
+
+answerRevealed
+  └─► navigating             (player taps "Onward!" / "Continue")
+
+navigating (lives == 0)
+  └─► gameOver
+```
+
+Skipping: player dismisses question sheet without answering → `DoorState.skipped`, `RoomStatus.skipped`, stays `navigating`.
+
+---
+
+## Question assignment
+- Generate 10×10 = 100 cells
+- Throne Room: no question (win condition room)
+- Start cell: no question (entry point)
+- Remaining 98 cells each get 1 question, drawn with `selectQuestionsFrom(config)`
+- If question pool < 98, questions repeat (shuffle + cycle)
+
+---
+
+## Lives
+- Start: 3
+- Wrong answer: `lives -= 1`
+- If `lives == 0` after wrong answer: transition to `gameOver`
+- No life restoration in v1 (XP system out of scope)

--- a/ai/tasks/maze-mode/proposal/02-maze-generation.md
+++ b/ai/tasks/maze-mode/proposal/02-maze-generation.md
@@ -1,0 +1,76 @@
+# Proposal 02: Maze Generation
+
+## Algorithm: Recursive Backtracker (DFS)
+
+Standard algorithm that produces a **perfect maze** (exactly one path between any two cells, no isolated cells). Every cell is reachable from the start. Produces long winding corridors — good for exploration.
+
+### Steps
+1. Start at cell (0,0).
+2. Mark current cell visited.
+3. While unvisited neighbors exist:
+   a. Pick a random unvisited neighbor.
+   b. Remove the wall between current and chosen (add connection `DoorState.locked`).
+   c. Recurse into chosen.
+4. Backtrack when no unvisited neighbors remain.
+
+All walls not carved remain `DoorState.wall`.
+
+### Throne Room placement
+- After generation, compute **distance from start** for all cells (BFS).
+- Place Throne Room at the cell with **maximum distance**.
+- This guarantees the player must traverse most of the maze to win.
+
+### Question assignment
+```dart
+// 1. Collect all cells except start and throne
+// 2. Call selectQuestionsFrom(config, count: cells.length) — cycles if needed
+// 3. Assign one QuizQuestion per cell in shuffled order
+```
+
+### Seeding
+- Use `Random(seed)` where seed = `DateTime.now().millisecondsSinceEpoch`
+- Store seed in `MazeState` for potential future replay/debug use
+
+---
+
+## `MazeGenerator` API
+
+```dart
+class MazeGenerator {
+  /// Returns a fully initialized MazeState ready to play.
+  static MazeState generate({
+    required QuizConfig config,
+    required List<QuizQuestion> questionPool,
+    int seed,
+  });
+}
+```
+
+Pure function — no side effects, fully testable.
+
+---
+
+## Grid representation
+
+`grid[y][x]` — row 0 is top, column 0 is left.
+
+Player starts at `(x:0, y:0)` (top-left). Throne Room at max-distance cell.
+
+---
+
+## Fog of war rules
+Applied during render, not stored (derived from `RoomStatus`):
+- `hidden` → cell not visible to player
+- `visible` → cell is adjacent (N/S/E/W) to any visited/answered/skipped cell
+- `visited+` → always shown
+
+The `throneDiscovered` flag is set when the throne becomes `visible` (adjacent), revealing its icon on the map.
+
+---
+
+## Validation
+After generation, assert:
+- All 100 cells are reachable from (0,0) (BFS count == 100)
+- Exactly 1 throne room
+- Start cell has no question, throne room has no question
+- Connection map contains exactly 99 connections (spanning tree: n-1 edges for n=100)

--- a/ai/tasks/maze-mode/proposal/03-maze-ui.md
+++ b/ai/tasks/maze-mode/proposal/03-maze-ui.md
@@ -1,0 +1,82 @@
+# Proposal 03: Maze UI & Navigation
+
+## Screens
+
+### `/maze-settings` — MazeSettingsScreen
+- Reuses topic picker and difficulty UI from GameSettingsScreen
+- "Enter the Maze" CTA button
+- Passes `QuizConfig` to maze generator
+
+### `/maze` — MazeScreen
+Main screen. Two layers:
+
+#### Top: MazeMapWidget (scrollable/zoomable grid)
+- Renders a 10×10 grid of cells
+- Cell display by status:
+  | Status | Appearance |
+  |--------|-----------|
+  | `hidden` | Black / dark stone, no icon |
+  | `visible` | Dim stone, faint outline |
+  | `visited` | Stone colour, room door icon |
+  | `answered` | Gold glow, open door icon |
+  | `skipped` | Muted amber, half-open door |
+  | Throne (discovered) | Throne icon, shimmer |
+  | Player position | Knight/torch icon on top of room |
+- Walls between cells rendered as thick borders, open passages as thin/no border
+- Player position centred in view
+
+#### Bottom: ActionPanel
+- Shows current room context (topic name, door state)
+- If room has unanswered question: "Answer Question" + "Skip Room" buttons
+- If room already answered/skipped: direction arrows (N/S/E/W) or just map navigation
+- Lives widget (top bar, 3 flame icons)
+
+### Question Sheet (bottom sheet, same UX as GameplayScreen)
+- Question card with 4 answer options
+- On answer: reveal correct/wrong, show fun fact
+- "Onward!" button → dismiss sheet, return to maze navigation
+- Skip: separate "Skip this room" text button → dismiss without answering
+
+---
+
+## Navigation model
+Player taps a **direction arrow** (or adjacent visible cell on map) to move.
+
+Movement rules:
+1. Target cell must be **connected** (no wall in that direction).
+2. If target is visited/answered/skipped → move freely.
+3. If target is unvisited and has a question → open Question Sheet before committing move.
+4. If target is unvisited and has no question → move directly, mark `visited`.
+5. If target is Throne Room → move, trigger `complete`.
+
+### Direction input
+Four arrow buttons (↑ ↓ ← →) shown below the map. Disabled if wall in that direction.
+
+---
+
+## Results screen (reuse existing)
+- Navigate to `/results` with a `MazeResultsExtra` containing: rooms visited, questions answered, correct count, lives remaining
+- Reuse ResultsScreen with a maze-specific summary card
+
+---
+
+## Colour usage (AppColors)
+| Element | Colour |
+|---------|--------|
+| Hidden cell | `background` (#1A1208) |
+| Visible cell | `stone` (#3D3020) |
+| Answered cell | `torchGold` (#FFD700) glow |
+| Skipped cell | `torchAmber` (#FF8C00) dim |
+| Wrong answer flash | `dangerRed` (#C0392B) |
+| Player icon | `parchment` (#F5E6C8) |
+| Throne (discovered) | `torchGold` pulse |
+
+---
+
+## Animations
+All use `flutter_animate`:
+- Cell reveal (fog lift): fade + scale in ~200ms
+- Player movement: position tween ~150ms
+- Throne discovery: shimmer pulse
+- Answer correct: cell flashes gold
+- Answer wrong: cell shakes + red flash

--- a/ai/tasks/maze-mode/research/codebase.md
+++ b/ai/tasks/maze-mode/research/codebase.md
@@ -1,0 +1,35 @@
+# Research: Maze Mode — Codebase Findings
+
+## Key models
+
+### GameState (`lib/features/gameplay/domain/models/game_state.dart`)
+Linear progress: `currentQuestionIndex`, `lives` (start 3), `score`, `status`, `streak`.
+Status enum: `idle | loading | playing | answerRevealed | gameOver | complete`
+All models are immutable with `copyWith`.
+
+### Room (`lib/features/gameplay/domain/models/room.dart`)
+Exists but **unused in GameState**. Has `index`, `theme`, `completed`, `answeredCorrectly`.
+Safe to repurpose the concept; do not modify this file.
+
+### QuizQuestion (runtime) / Question (source)
+Source lives in `assets/questions/topics/{topicId}.json`.
+Runtime: 4 shuffled options, `correctIndex`.
+`selectQuestionsFrom()` in `question_bank.dart` is reusable as-is.
+
+## State provider
+`GameStateNotifier extends Notifier<GameState?>` — `startGame`, `answerQuestion`, `advanceQuestion`.
+Maze mode should use a **separate** `MazeStateNotifier` to avoid coupling.
+
+## Routes (lib/app.dart)
+GoRouter. Current: `/`, `/mode`, `/game-settings`, `/topics`, `/game`, `/article`, `/results`, `/notebook`, `/settings`, `/how-to-play`, `/feedback`, `/stats`.
+Adding `/maze-settings` and `/maze` is straightforward.
+
+## Dependencies relevant to maze
+- `flutter_animate: ^4.5.0` — cell animations, reveal effects
+- `shared_preferences` — could persist maze seed between sessions (out of scope for v1)
+- `maze_builder` — **NOT in pubspec**; owner suggested it but it is optional
+
+## Tests
+- `test/features/gameplay/domain/game_state_test.dart` — pure domain unit tests
+- `test/question_bank_test.dart` — question selection
+- Tests are pure Dart; pattern is `group`/`test`; no mocks needed for domain logic.

--- a/release_notes.md
+++ b/release_notes.md
@@ -12,7 +12,7 @@
 - (none)
 
 ### Other
-- (none)
+- Add AI task plan for Maze Mode core game (#40)
 ---
 
 ## v1.0.53


### PR DESCRIPTION
## Summary
- Adds AI task plan for the Maze Mode core game feature (issue #40)
- Documents domain model design, maze generation algorithm, and UI spec across three proposals
- Establishes the implementation order of operations — no code changes yet

## What's in this PR
| File | Purpose |
|------|---------|
| `ai/tasks/maze-mode/plan.md` | Authoritative plan: models, architecture, 16-step order of operations |
| `ai/tasks/maze-mode/proposal/01-maze-state-model.md` | `MazeState`, `MazeRoom`, `DoorState`, `RoomStatus`, `MazeStatus` model design |
| `ai/tasks/maze-mode/proposal/02-maze-generation.md` | Recursive backtracker DFS, Throne Room placement, fog-of-war rules |
| `ai/tasks/maze-mode/proposal/03-maze-ui.md` | Screen layout, colour usage, animation spec |
| `ai/tasks/maze-mode/research/codebase.md` | Key codebase findings that shaped the design |

## Key design decisions
- **Fully additive** — existing standard/endless modes untouched; new `lib/features/maze/` subtree
- **Separate state** — `MazeStateNotifier` is independent of `GameStateNotifier`; reuses `QuizQuestion` and `selectQuestionsFrom()` as-is
- **Perfect maze** (recursive backtracker DFS) — one path between any two cells; Throne Room at maximum BFS distance from start
- **XP system excluded** from v1 per owner direction

## Test plan
- [ ] Review domain model proposal (`01-maze-state-model.md`) for completeness
- [ ] Review generation algorithm (`02-maze-generation.md`) — connectivity guarantee, throne placement
- [ ] Review UI spec (`03-maze-ui.md`) — fog of war, colour usage, direction input
- [ ] Approve plan before implementation begins

Closes #40

https://claude.ai/code/session_01SLBZB5HpmnvGNH5P3yQjaY