### PR TITLE
feat: Maze Mode core game (#40)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -16,6 +16,8 @@ import 'features/start/presentation/screens/how_to_play_screen.dart';
 import 'features/start/presentation/screens/mode_picker_screen.dart';
 import 'features/start/presentation/screens/game_settings_screen.dart';
 import 'features/settings/presentation/screens/settings_screen.dart';
+import 'features/maze/presentation/screens/maze_settings_screen.dart';
+import 'features/maze/presentation/screens/maze_screen.dart';
 
 final _router = GoRouter(
   initialLocation: '/',
@@ -57,6 +59,10 @@ final _router = GoRouter(
     GoRoute(path: '/how-to-play', builder: (_, __) => const HowToPlayScreen()),
     GoRoute(path: '/mode', builder: (_, __) => const ModePickerScreen()),
     GoRoute(path: '/settings', builder: (_, __) => const SettingsScreen()),
+    GoRoute(
+        path: '/maze-settings',
+        builder: (_, __) => const MazeSettingsScreen()),
+    GoRoute(path: '/maze', builder: (_, __) => const MazeScreen()),
   ],
 );
 

--- a/lib/features/maze/data/maze_generator.dart
+++ b/lib/features/maze/data/maze_generator.dart
@@ -13,6 +13,13 @@ import '../domain/models/room_status.dart';
 
 const _kSize = 10;
 
+const _kDirections = [
+  MazePosition(0, -1),
+  MazePosition(0, 1),
+  MazePosition(-1, 0),
+  MazePosition(1, 0),
+];
+
 class MazeGenerator {
   /// Returns a fully initialised [MazeState] ready to play.
   static MazeState generate({
@@ -23,7 +30,106 @@ class MazeGenerator {
     final effectiveSeed = seed ?? DateTime.now().millisecondsSinceEpoch;
     final rng = Random(effectiveSeed);
 
-    // ── 1. Build grid of rooms (all hidden, no questions yet) ──────────────
+    final connections = _carveMaze(rng);
+    final thronePos = _findThronePosition(connections);
+    final (grid, questionMap) = _buildGrid(
+      thronePos: thronePos,
+      questionPool: questionPool,
+      config: config,
+      rng: rng,
+    );
+
+    return MazeState(
+      grid: grid,
+      connections: connections,
+      playerPosition: const MazePosition(0, 0),
+      thronePosition: thronePos,
+      questions: questionMap,
+      lives: 3,
+      status: MazeStatus.navigating,
+      config: config,
+      seed: effectiveSeed,
+    );
+  }
+
+  /// Recursive backtracker DFS — carves a perfect maze and returns the
+  /// connection map (`connectionKey → DoorState.locked`).
+  static Map<String, DoorState> _carveMaze(Random rng) {
+    final connections = <String, DoorState>{};
+    final visited = List.generate(_kSize, (_) => List.filled(_kSize, false));
+
+    void dfs(int x, int y) {
+      visited[y][x] = true;
+      final dirs = List<MazePosition>.from(_kDirections)..shuffle(rng);
+      for (final d in dirs) {
+        final nx = x + d.x;
+        final ny = y + d.y;
+        if (nx < 0 || ny < 0 || nx >= _kSize || ny >= _kSize) continue;
+        if (visited[ny][nx]) continue;
+        connections[connectionKey(MazePosition(x, y), MazePosition(nx, ny))] =
+            DoorState.locked;
+        dfs(nx, ny);
+      }
+    }
+
+    dfs(0, 0);
+    return connections;
+  }
+
+  /// BFS from (0,0) — returns the cell at maximum graph distance (throne).
+  static MazePosition _findThronePosition(Map<String, DoorState> connections) {
+    final dist = List.generate(_kSize, (_) => List.filled(_kSize, -1));
+    dist[0][0] = 0;
+    final queue = Queue<MazePosition>()..add(const MazePosition(0, 0));
+
+    while (queue.isNotEmpty) {
+      final cur = queue.removeFirst();
+      for (final n in _passableNeighbours(cur, connections)) {
+        if (dist[n.y][n.x] == -1) {
+          dist[n.y][n.x] = dist[cur.y][cur.x] + 1;
+          queue.add(n);
+        }
+      }
+    }
+
+    int maxDist = 0;
+    MazePosition throne = const MazePosition(_kSize - 1, _kSize - 1);
+    for (int y = 0; y < _kSize; y++) {
+      for (int x = 0; x < _kSize; x++) {
+        if (dist[y][x] > maxDist) {
+          maxDist = dist[y][x];
+          throne = MazePosition(x, y);
+        }
+      }
+    }
+    return throne;
+  }
+
+  /// Builds the 10×10 room grid and question map.
+  /// Start cell and throne room have no question; all other cells get one.
+  static (List<List<MazeRoom>>, Map<String, QuizQuestion>) _buildGrid({
+    required MazePosition thronePos,
+    required List<Question> questionPool,
+    required QuizConfig config,
+    required Random rng,
+  }) {
+    const startPos = MazePosition(0, 0);
+
+    final questionCells = [
+      for (int y = 0; y < _kSize; y++)
+        for (int x = 0; x < _kSize; x++)
+          if (MazePosition(x, y) != startPos && MazePosition(x, y) != thronePos)
+            MazePosition(x, y),
+    ];
+
+    final quizQuestions = _selectQuestions(
+      questionPool,
+      config: config,
+      count: questionCells.length,
+      rng: rng,
+    );
+
+    final questionMap = <String, QuizQuestion>{};
     final grid = List.generate(
       _kSize,
       (y) => List.generate(
@@ -34,160 +140,69 @@ class MazeGenerator {
       growable: false,
     );
 
-    // ── 2. Recursive backtracker DFS to carve passages ────────────────────
-    final connections = <String, DoorState>{};
-    final visited = List.generate(_kSize, (_) => List.filled(_kSize, false));
+    _assignQuestions(grid, questionCells, quizQuestions, questionMap);
+    _markThroneRoom(grid, thronePos);
+    _initFogOfWar(grid, startPos);
 
-    void dfs(int x, int y) {
-      visited[y][x] = true;
-      final dirs = [
-        MazePosition(0, -1),
-        MazePosition(0, 1),
-        MazePosition(-1, 0),
-        MazePosition(1, 0),
-      ]..shuffle(rng);
+    return (grid, questionMap);
+  }
 
-      for (final d in dirs) {
-        final nx = x + d.x;
-        final ny = y + d.y;
-        if (nx < 0 || ny < 0 || nx >= _kSize || ny >= _kSize) continue;
-        if (visited[ny][nx]) continue;
-        final key = connectionKey(MazePosition(x, y), MazePosition(nx, ny));
-        connections[key] = DoorState.locked;
-        dfs(nx, ny);
-      }
+  static void _assignQuestions(
+    List<List<MazeRoom>> grid,
+    List<MazePosition> cells,
+    List<QuizQuestion> questions,
+    Map<String, QuizQuestion> questionMap,
+  ) {
+    if (questions.isEmpty) return;
+    for (int i = 0; i < cells.length; i++) {
+      final pos = cells[i];
+      final q = questions[i % questions.length];
+      final qId = '${pos.y}_${pos.x}';
+      questionMap[qId] = q;
+      grid[pos.y][pos.x] = MazeRoom(
+        position: pos,
+        questionId: qId,
+        status: RoomStatus.hidden,
+      );
     }
+  }
 
-    dfs(0, 0);
-
-    // ── 3. BFS from (0,0) to find throne position (max distance) ──────────
-    final dist = List.generate(_kSize, (_) => List.filled(_kSize, -1));
-    dist[0][0] = 0;
-    final queue = Queue<MazePosition>();
-    queue.add(const MazePosition(0, 0));
-
-    while (queue.isNotEmpty) {
-      final cur = queue.removeFirst();
-      for (final neighbour in _neighbours(cur, connections)) {
-        if (dist[neighbour.y][neighbour.x] == -1) {
-          dist[neighbour.y][neighbour.x] = dist[cur.y][cur.x] + 1;
-          queue.add(neighbour);
-        }
-      }
-    }
-
-    int maxDist = 0;
-    MazePosition thronePos = const MazePosition(_kSize - 1, _kSize - 1);
-    for (int y = 0; y < _kSize; y++) {
-      for (int x = 0; x < _kSize; x++) {
-        if (dist[y][x] > maxDist) {
-          maxDist = dist[y][x];
-          thronePos = MazePosition(x, y);
-        }
-      }
-    }
-
-    // ── 4. Assign questions to all cells except start and throne ──────────
-    final questionCells = <MazePosition>[];
-    for (int y = 0; y < _kSize; y++) {
-      for (int x = 0; x < _kSize; x++) {
-        final pos = MazePosition(x, y);
-        if (pos == const MazePosition(0, 0)) continue;
-        if (pos == thronePos) continue;
-        questionCells.add(pos);
-      }
-    }
-
-    final quizQuestions = _selectQuestions(
-      questionPool,
-      config: config,
-      count: questionCells.length,
-      rng: rng,
-    );
-
-    final questionMap = <String, QuizQuestion>{};
-    final updatedGrid = List.generate(
-      _kSize,
-      (y) => List.generate(_kSize, (x) => grid[y][x], growable: false),
-      growable: false,
-    );
-
-    if (quizQuestions.isNotEmpty) {
-      for (int i = 0; i < questionCells.length; i++) {
-        final pos = questionCells[i];
-        final q = quizQuestions[i % quizQuestions.length];
-        final qId = '${pos.y}_${pos.x}';
-        questionMap[qId] = q;
-        updatedGrid[pos.y][pos.x] = MazeRoom(
-          position: pos,
-          questionId: qId,
-          status: RoomStatus.hidden,
-        );
-      }
-    }
-
-    // Mark throne room
-    updatedGrid[thronePos.y][thronePos.x] = MazeRoom(
-      position: thronePos,
+  static void _markThroneRoom(List<List<MazeRoom>> grid, MazePosition pos) {
+    grid[pos.y][pos.x] = MazeRoom(
+      position: pos,
       isThroneRoom: true,
       status: RoomStatus.hidden,
     );
-
-    // ── 5. Reveal start cell and its neighbours ────────────────────────────
-    updatedGrid[0][0] = MazeRoom(
-      position: const MazePosition(0, 0),
-      status: RoomStatus.visited,
-    );
-
-    const startPos = MazePosition(0, 0);
-    const neighbourOffsets = [
-      MazePosition(0, -1),
-      MazePosition(0, 1),
-      MazePosition(-1, 0),
-      MazePosition(1, 0),
-    ];
-    for (final d in neighbourOffsets) {
-      final nx = startPos.x + d.x;
-      final ny = startPos.y + d.y;
-      if (nx < 0 || ny < 0 || nx >= _kSize || ny >= _kSize) continue;
-      if (updatedGrid[ny][nx].status == RoomStatus.hidden) {
-        updatedGrid[ny][nx] = updatedGrid[ny][nx].copyWith(
-          status: RoomStatus.visible,
-        );
-      }
-    }
-
-    return MazeState(
-      grid: updatedGrid,
-      connections: connections,
-      playerPosition: startPos,
-      thronePosition: thronePos,
-      questions: questionMap,
-      lives: 3,
-      status: MazeStatus.navigating,
-      config: config,
-      seed: effectiveSeed,
-    );
   }
 
-  static List<MazePosition> _neighbours(
+  static void _initFogOfWar(List<List<MazeRoom>> grid, MazePosition start) {
+    grid[start.y][start.x] = MazeRoom(
+      position: start,
+      status: RoomStatus.visited,
+    );
+    for (final d in _kDirections) {
+      final nx = start.x + d.x;
+      final ny = start.y + d.y;
+      if (nx < 0 || ny < 0 || nx >= _kSize || ny >= _kSize) continue;
+      if (grid[ny][nx].status == RoomStatus.hidden) {
+        grid[ny][nx] = grid[ny][nx].copyWith(status: RoomStatus.visible);
+      }
+    }
+  }
+
+  static List<MazePosition> _passableNeighbours(
     MazePosition pos,
     Map<String, DoorState> connections,
   ) {
-    const offsets = [
-      MazePosition(0, -1),
-      MazePosition(0, 1),
-      MazePosition(-1, 0),
-      MazePosition(1, 0),
-    ];
     final result = <MazePosition>[];
-    for (final d in offsets) {
+    for (final d in _kDirections) {
       final nx = pos.x + d.x;
       final ny = pos.y + d.y;
       if (nx < 0 || ny < 0 || nx >= _kSize || ny >= _kSize) continue;
       final neighbour = MazePosition(nx, ny);
-      final key = connectionKey(pos, neighbour);
-      if (connections.containsKey(key)) result.add(neighbour);
+      if (connections.containsKey(connectionKey(pos, neighbour))) {
+        result.add(neighbour);
+      }
     }
     return result;
   }
@@ -199,20 +214,14 @@ class MazeGenerator {
     required int count,
     required Random rng,
   }) {
-    if (pool.isEmpty) {
-      // Fallback: return empty — MazeState will handle rooms with no question
-      return [];
-    }
+    if (pool.isEmpty) return [];
 
-    // Use selectQuestionsFrom for proper difficulty weighting.
-    // If the pool is smaller than count, cycle by requesting from multiple rounds.
-    final List<QuizQuestion> result = [];
+    final result = <QuizQuestion>[];
     while (result.length < count) {
-      final need = count - result.length;
       final batch = selectQuestionsFrom(
         pool,
         topicIds: config.selectedTopicIds,
-        count: min(need, pool.length),
+        count: min(count - result.length, pool.length),
         difficultyBias: config.difficultyBias,
         rng: rng,
       );

--- a/lib/features/maze/data/maze_generator.dart
+++ b/lib/features/maze/data/maze_generator.dart
@@ -1,0 +1,224 @@
+import 'dart:collection';
+import 'dart:math';
+
+import '../../gameplay/data/question_bank.dart';
+import '../../gameplay/domain/models/question.dart';
+import '../../gameplay/domain/models/quiz_config.dart';
+import '../domain/models/door_state.dart';
+import '../domain/models/maze_position.dart';
+import '../domain/models/maze_room.dart';
+import '../domain/models/maze_state.dart';
+import '../domain/models/maze_status.dart';
+import '../domain/models/room_status.dart';
+
+const _kSize = 10;
+
+class MazeGenerator {
+  /// Returns a fully initialised [MazeState] ready to play.
+  static MazeState generate({
+    required QuizConfig config,
+    required List<Question> questionPool,
+    int? seed,
+  }) {
+    final effectiveSeed = seed ?? DateTime.now().millisecondsSinceEpoch;
+    final rng = Random(effectiveSeed);
+
+    // ── 1. Build grid of rooms (all hidden, no questions yet) ──────────────
+    final grid = List.generate(
+      _kSize,
+      (y) => List.generate(
+        _kSize,
+        (x) => MazeRoom(position: MazePosition(x, y)),
+        growable: false,
+      ),
+      growable: false,
+    );
+
+    // ── 2. Recursive backtracker DFS to carve passages ────────────────────
+    final connections = <String, DoorState>{};
+    final visited = List.generate(_kSize, (_) => List.filled(_kSize, false));
+
+    void dfs(int x, int y) {
+      visited[y][x] = true;
+      final dirs = [
+        MazePosition(0, -1),
+        MazePosition(0, 1),
+        MazePosition(-1, 0),
+        MazePosition(1, 0),
+      ]..shuffle(rng);
+
+      for (final d in dirs) {
+        final nx = x + d.x;
+        final ny = y + d.y;
+        if (nx < 0 || ny < 0 || nx >= _kSize || ny >= _kSize) continue;
+        if (visited[ny][nx]) continue;
+        final key = connectionKey(MazePosition(x, y), MazePosition(nx, ny));
+        connections[key] = DoorState.locked;
+        dfs(nx, ny);
+      }
+    }
+
+    dfs(0, 0);
+
+    // ── 3. BFS from (0,0) to find throne position (max distance) ──────────
+    final dist = List.generate(_kSize, (_) => List.filled(_kSize, -1));
+    dist[0][0] = 0;
+    final queue = Queue<MazePosition>();
+    queue.add(const MazePosition(0, 0));
+
+    while (queue.isNotEmpty) {
+      final cur = queue.removeFirst();
+      for (final neighbour in _neighbours(cur, connections)) {
+        if (dist[neighbour.y][neighbour.x] == -1) {
+          dist[neighbour.y][neighbour.x] = dist[cur.y][cur.x] + 1;
+          queue.add(neighbour);
+        }
+      }
+    }
+
+    int maxDist = 0;
+    MazePosition thronePos = const MazePosition(_kSize - 1, _kSize - 1);
+    for (int y = 0; y < _kSize; y++) {
+      for (int x = 0; x < _kSize; x++) {
+        if (dist[y][x] > maxDist) {
+          maxDist = dist[y][x];
+          thronePos = MazePosition(x, y);
+        }
+      }
+    }
+
+    // ── 4. Assign questions to all cells except start and throne ──────────
+    final questionCells = <MazePosition>[];
+    for (int y = 0; y < _kSize; y++) {
+      for (int x = 0; x < _kSize; x++) {
+        final pos = MazePosition(x, y);
+        if (pos == const MazePosition(0, 0)) continue;
+        if (pos == thronePos) continue;
+        questionCells.add(pos);
+      }
+    }
+
+    final quizQuestions = _selectQuestions(
+      questionPool,
+      config: config,
+      count: questionCells.length,
+      rng: rng,
+    );
+
+    final questionMap = <String, QuizQuestion>{};
+    final updatedGrid = List.generate(
+      _kSize,
+      (y) => List.generate(_kSize, (x) => grid[y][x], growable: false),
+      growable: false,
+    );
+
+    if (quizQuestions.isNotEmpty) {
+      for (int i = 0; i < questionCells.length; i++) {
+        final pos = questionCells[i];
+        final q = quizQuestions[i % quizQuestions.length];
+        final qId = '${pos.y}_${pos.x}';
+        questionMap[qId] = q;
+        updatedGrid[pos.y][pos.x] = MazeRoom(
+          position: pos,
+          questionId: qId,
+          status: RoomStatus.hidden,
+        );
+      }
+    }
+
+    // Mark throne room
+    updatedGrid[thronePos.y][thronePos.x] = MazeRoom(
+      position: thronePos,
+      isThroneRoom: true,
+      status: RoomStatus.hidden,
+    );
+
+    // ── 5. Reveal start cell and its neighbours ────────────────────────────
+    updatedGrid[0][0] = MazeRoom(
+      position: const MazePosition(0, 0),
+      status: RoomStatus.visited,
+    );
+
+    const startPos = MazePosition(0, 0);
+    const neighbourOffsets = [
+      MazePosition(0, -1),
+      MazePosition(0, 1),
+      MazePosition(-1, 0),
+      MazePosition(1, 0),
+    ];
+    for (final d in neighbourOffsets) {
+      final nx = startPos.x + d.x;
+      final ny = startPos.y + d.y;
+      if (nx < 0 || ny < 0 || nx >= _kSize || ny >= _kSize) continue;
+      if (updatedGrid[ny][nx].status == RoomStatus.hidden) {
+        updatedGrid[ny][nx] = updatedGrid[ny][nx].copyWith(
+          status: RoomStatus.visible,
+        );
+      }
+    }
+
+    return MazeState(
+      grid: updatedGrid,
+      connections: connections,
+      playerPosition: startPos,
+      thronePosition: thronePos,
+      questions: questionMap,
+      lives: 3,
+      status: MazeStatus.navigating,
+      config: config,
+      seed: effectiveSeed,
+    );
+  }
+
+  static List<MazePosition> _neighbours(
+    MazePosition pos,
+    Map<String, DoorState> connections,
+  ) {
+    const offsets = [
+      MazePosition(0, -1),
+      MazePosition(0, 1),
+      MazePosition(-1, 0),
+      MazePosition(1, 0),
+    ];
+    final result = <MazePosition>[];
+    for (final d in offsets) {
+      final nx = pos.x + d.x;
+      final ny = pos.y + d.y;
+      if (nx < 0 || ny < 0 || nx >= _kSize || ny >= _kSize) continue;
+      final neighbour = MazePosition(nx, ny);
+      final key = connectionKey(pos, neighbour);
+      if (connections.containsKey(key)) result.add(neighbour);
+    }
+    return result;
+  }
+
+  /// Select [count] questions from [pool], cycling if pool is too small.
+  static List<QuizQuestion> _selectQuestions(
+    List<Question> pool, {
+    required QuizConfig config,
+    required int count,
+    required Random rng,
+  }) {
+    if (pool.isEmpty) {
+      // Fallback: return empty — MazeState will handle rooms with no question
+      return [];
+    }
+
+    // Use selectQuestionsFrom for proper difficulty weighting.
+    // If the pool is smaller than count, cycle by requesting from multiple rounds.
+    final List<QuizQuestion> result = [];
+    while (result.length < count) {
+      final need = count - result.length;
+      final batch = selectQuestionsFrom(
+        pool,
+        topicIds: config.selectedTopicIds,
+        count: min(need, pool.length),
+        difficultyBias: config.difficultyBias,
+        rng: rng,
+      );
+      if (batch.isEmpty) break;
+      result.addAll(batch);
+    }
+    return result.take(count).toList();
+  }
+}

--- a/lib/features/maze/domain/models/door_state.dart
+++ b/lib/features/maze/domain/models/door_state.dart
@@ -1,0 +1,6 @@
+enum DoorState {
+  wall,    // no passage between cells
+  locked,  // passage exists, question not yet answered
+  open,    // answered correctly
+  skipped, // player bypassed without answering
+}

--- a/lib/features/maze/domain/models/maze_position.dart
+++ b/lib/features/maze/domain/models/maze_position.dart
@@ -1,0 +1,16 @@
+class MazePosition {
+  final int x;
+  final int y;
+
+  const MazePosition(this.x, this.y);
+
+  @override
+  bool operator ==(Object other) =>
+      other is MazePosition && other.x == x && other.y == y;
+
+  @override
+  int get hashCode => Object.hash(x, y);
+
+  @override
+  String toString() => '($x,$y)';
+}

--- a/lib/features/maze/domain/models/maze_room.dart
+++ b/lib/features/maze/domain/models/maze_room.dart
@@ -1,0 +1,31 @@
+import 'maze_position.dart';
+import 'room_status.dart';
+
+class MazeRoom {
+  final MazePosition position;
+  final String? questionId;
+  final bool isThroneRoom;
+  final RoomStatus status;
+  final bool? answeredCorrectly;
+
+  const MazeRoom({
+    required this.position,
+    this.questionId,
+    this.isThroneRoom = false,
+    this.status = RoomStatus.hidden,
+    this.answeredCorrectly,
+  });
+
+  MazeRoom copyWith({
+    RoomStatus? status,
+    bool? answeredCorrectly,
+  }) {
+    return MazeRoom(
+      position: position,
+      questionId: questionId,
+      isThroneRoom: isThroneRoom,
+      status: status ?? this.status,
+      answeredCorrectly: answeredCorrectly ?? this.answeredCorrectly,
+    );
+  }
+}

--- a/lib/features/maze/domain/models/maze_state.dart
+++ b/lib/features/maze/domain/models/maze_state.dart
@@ -1,0 +1,248 @@
+import '../../../gameplay/domain/models/question.dart';
+import '../../../gameplay/domain/models/quiz_config.dart';
+import 'door_state.dart';
+import 'maze_position.dart';
+import 'maze_room.dart';
+import 'maze_status.dart';
+import 'room_status.dart';
+
+/// Canonical key for the edge between two adjacent cells.
+/// Always puts the cell with smaller (y, x) first.
+String connectionKey(MazePosition a, MazePosition b) {
+  final first = (a.y < b.y || (a.y == b.y && a.x < b.x)) ? a : b;
+  final second = first == a ? b : a;
+  return '${first.y},${first.x}-${second.y},${second.x}';
+}
+
+class MazeState {
+  /// Row-major: grid[y][x]
+  final List<List<MazeRoom>> grid;
+
+  /// Edge map: connectionKey → DoorState
+  final Map<String, DoorState> connections;
+
+  final MazePosition playerPosition;
+
+  /// Position from which the player entered the current room (null at start).
+  final MazePosition? entryFrom;
+
+  final MazePosition thronePosition;
+  final bool throneDiscovered;
+
+  /// questionId → QuizQuestion
+  final Map<String, QuizQuestion> questions;
+
+  final int lives;
+  final MazeStatus status;
+  final QuizConfig config;
+  final QuizQuestion? activeQuestion;
+  final bool? lastAnswerCorrect;
+  final int seed;
+
+  const MazeState({
+    required this.grid,
+    required this.connections,
+    required this.playerPosition,
+    this.entryFrom,
+    required this.thronePosition,
+    this.throneDiscovered = false,
+    required this.questions,
+    required this.lives,
+    required this.status,
+    required this.config,
+    this.activeQuestion,
+    this.lastAnswerCorrect,
+    this.seed = 0,
+  });
+
+  MazeRoom roomAt(MazePosition pos) => grid[pos.y][pos.x];
+
+  DoorState doorBetween(MazePosition a, MazePosition b) =>
+      connections[connectionKey(a, b)] ?? DoorState.wall;
+
+  bool get isGameOver => status == MazeStatus.gameOver;
+  bool get isComplete => status == MazeStatus.complete;
+
+  int get roomsVisited => grid
+      .expand((row) => row)
+      .where((r) =>
+          r.status == RoomStatus.visited ||
+          r.status == RoomStatus.answered ||
+          r.status == RoomStatus.skipped)
+      .length;
+
+  int get questionsAnswered =>
+      grid.expand((row) => row).where((r) => r.answeredCorrectly != null).length;
+
+  int get correctCount =>
+      grid.expand((row) => row).where((r) => r.answeredCorrectly == true).length;
+
+  MazeState copyWith({
+    List<List<MazeRoom>>? grid,
+    Map<String, DoorState>? connections,
+    MazePosition? playerPosition,
+    MazePosition? entryFrom,
+    MazePosition? thronePosition,
+    bool? throneDiscovered,
+    Map<String, QuizQuestion>? questions,
+    int? lives,
+    MazeStatus? status,
+    QuizConfig? config,
+    QuizQuestion? activeQuestion,
+    bool? lastAnswerCorrect,
+    int? seed,
+    bool clearEntryFrom = false,
+    bool clearActiveQuestion = false,
+    bool clearLastAnswer = false,
+  }) {
+    return MazeState(
+      grid: grid ?? this.grid,
+      connections: connections ?? this.connections,
+      playerPosition: playerPosition ?? this.playerPosition,
+      entryFrom: clearEntryFrom ? null : (entryFrom ?? this.entryFrom),
+      thronePosition: thronePosition ?? this.thronePosition,
+      throneDiscovered: throneDiscovered ?? this.throneDiscovered,
+      questions: questions ?? this.questions,
+      lives: lives ?? this.lives,
+      status: status ?? this.status,
+      config: config ?? this.config,
+      activeQuestion:
+          clearActiveQuestion ? null : (activeQuestion ?? this.activeQuestion),
+      lastAnswerCorrect:
+          clearLastAnswer ? null : (lastAnswerCorrect ?? this.lastAnswerCorrect),
+      seed: seed ?? this.seed,
+    );
+  }
+
+  MazeState _updateRoom(MazePosition pos, MazeRoom updated) {
+    final newGrid = [
+      for (int y = 0; y < grid.length; y++)
+        [
+          for (int x = 0; x < grid[y].length; x++)
+            (x == pos.x && y == pos.y) ? updated : grid[y][x],
+        ],
+    ];
+    return copyWith(grid: newGrid);
+  }
+
+  /// Reveal hidden cells adjacent to [pos].
+  MazeState _revealNeighbours(MazePosition pos) {
+    const offsets = [
+      MazePosition(0, -1),
+      MazePosition(0, 1),
+      MazePosition(-1, 0),
+      MazePosition(1, 0),
+    ];
+    var s = this;
+    for (final d in offsets) {
+      final nx = pos.x + d.x;
+      final ny = pos.y + d.y;
+      if (nx < 0 || ny < 0 || nx >= 10 || ny >= 10) continue;
+      final n = s.grid[ny][nx];
+      if (n.status == RoomStatus.hidden) {
+        s = s._updateRoom(
+          MazePosition(nx, ny),
+          n.copyWith(status: RoomStatus.visible),
+        );
+      }
+    }
+    return s;
+  }
+
+  /// Move the player to [target] (coming from [from]).
+  /// Handles throne win, fog reveal, question activation.
+  MazeState enterRoom(MazePosition target, {required MazePosition from}) {
+    final room = roomAt(target);
+
+    var s = _updateRoom(
+      target,
+      room.status == RoomStatus.hidden || room.status == RoomStatus.visible
+          ? room.copyWith(status: RoomStatus.visited)
+          : room,
+    );
+    s = s._revealNeighbours(target);
+
+    final throneAdjacent =
+        (thronePosition.x - target.x).abs() + (thronePosition.y - target.y).abs() == 1;
+
+    s = s.copyWith(
+      playerPosition: target,
+      entryFrom: from,
+      throneDiscovered: throneDiscovered || throneAdjacent,
+    );
+
+    if (room.isThroneRoom) {
+      return s.copyWith(status: MazeStatus.complete);
+    }
+
+    final qId = s.roomAt(target).questionId;
+    final needsQuestion = qId != null &&
+        room.status != RoomStatus.answered &&
+        room.status != RoomStatus.skipped;
+
+    if (needsQuestion) {
+      return s.copyWith(
+        status: MazeStatus.questionActive,
+        activeQuestion: s.questions[qId],
+        clearLastAnswer: true,
+      );
+    }
+
+    return s.copyWith(status: MazeStatus.navigating);
+  }
+
+  /// Record a correct answer and open the entry door.
+  MazeState answerCorrect() {
+    final room = roomAt(playerPosition);
+    var s = _updateRoom(
+      playerPosition,
+      room.copyWith(status: RoomStatus.answered, answeredCorrectly: true),
+    );
+    s = s._setEntryDoor(DoorState.open);
+    return s.copyWith(
+      status: MazeStatus.answerRevealed,
+      lastAnswerCorrect: true,
+    );
+  }
+
+  /// Deduct a life for a wrong answer; optionally trigger game over.
+  MazeState answerWrong() {
+    final newLives = lives - 1;
+    return copyWith(
+      lives: newLives,
+      status: newLives <= 0 ? MazeStatus.gameOver : MazeStatus.answerRevealed,
+      lastAnswerCorrect: false,
+    );
+  }
+
+  /// Skip this room's question.
+  MazeState skipRoom() {
+    final room = roomAt(playerPosition);
+    var s = _updateRoom(
+      playerPosition,
+      room.copyWith(status: RoomStatus.skipped, answeredCorrectly: false),
+    );
+    s = s._setEntryDoor(DoorState.skipped);
+    return s.copyWith(
+      status: MazeStatus.navigating,
+      clearActiveQuestion: true,
+      clearLastAnswer: true,
+    );
+  }
+
+  MazeState _setEntryDoor(DoorState doorState) {
+    if (entryFrom == null) return this;
+    final key = connectionKey(entryFrom!, playerPosition);
+    if (!connections.containsKey(key)) return this;
+    final newConnections = Map<String, DoorState>.from(connections)
+      ..[key] = doorState;
+    return copyWith(connections: newConnections);
+  }
+
+  /// Transition from answerRevealed → navigating.
+  MazeState dismissFunFact() => copyWith(
+        status: MazeStatus.navigating,
+        clearActiveQuestion: true,
+        clearLastAnswer: true,
+      );
+}

--- a/lib/features/maze/domain/models/maze_state.dart
+++ b/lib/features/maze/domain/models/maze_state.dart
@@ -14,6 +14,13 @@ String connectionKey(MazePosition a, MazePosition b) {
   return '${first.y},${first.x}-${second.y},${second.x}';
 }
 
+const _kDirections = [
+  MazePosition(0, -1),
+  MazePosition(0, 1),
+  MazePosition(-1, 0),
+  MazePosition(1, 0),
+];
+
 class MazeState {
   /// Row-major: grid[y][x]
   final List<List<MazeRoom>> grid;
@@ -127,14 +134,8 @@ class MazeState {
 
   /// Reveal hidden cells adjacent to [pos].
   MazeState _revealNeighbours(MazePosition pos) {
-    const offsets = [
-      MazePosition(0, -1),
-      MazePosition(0, 1),
-      MazePosition(-1, 0),
-      MazePosition(1, 0),
-    ];
     var s = this;
-    for (final d in offsets) {
+    for (final d in _kDirections) {
       final nx = pos.x + d.x;
       final ny = pos.y + d.y;
       if (nx < 0 || ny < 0 || nx >= 10 || ny >= 10) continue;

--- a/lib/features/maze/domain/models/maze_status.dart
+++ b/lib/features/maze/domain/models/maze_status.dart
@@ -1,0 +1,8 @@
+enum MazeStatus {
+  loading,
+  navigating,
+  questionActive,
+  answerRevealed,
+  complete,
+  gameOver,
+}

--- a/lib/features/maze/domain/models/room_status.dart
+++ b/lib/features/maze/domain/models/room_status.dart
@@ -1,0 +1,7 @@
+enum RoomStatus {
+  hidden,   // fog of war — not yet visible
+  visible,  // adjacent to a visited room, shown on map but not entered
+  visited,  // entered; question not answered (or no question)
+  answered, // question answered correctly
+  skipped,  // question skipped
+}

--- a/lib/features/maze/presentation/providers/maze_state_provider.dart
+++ b/lib/features/maze/presentation/providers/maze_state_provider.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../gameplay/data/question_repository.dart';
+import '../../../gameplay/domain/models/quiz_config.dart';
+import '../../data/maze_generator.dart';
+import '../../domain/models/door_state.dart';
+import '../../domain/models/maze_position.dart';
+import '../../domain/models/maze_state.dart';
+import '../../domain/models/maze_status.dart';
+
+enum Direction { north, south, east, west }
+
+extension DirectionOffset on Direction {
+  MazePosition get offset => switch (this) {
+        Direction.north => const MazePosition(0, -1),
+        Direction.south => const MazePosition(0, 1),
+        Direction.west => const MazePosition(-1, 0),
+        Direction.east => const MazePosition(1, 0),
+      };
+}
+
+class MazeStateNotifier extends Notifier<MazeState?> {
+  @override
+  MazeState? build() => null;
+
+  Future<void> startMaze(QuizConfig config) async {
+    state = null;
+    final pool = await loadQuestionsForTopics(config.selectedTopicIds);
+    state = MazeGenerator.generate(config: config, questionPool: pool);
+  }
+
+  void movePlayer(Direction direction) {
+    final s = state;
+    if (s == null || s.status != MazeStatus.navigating) return;
+
+    final offset = direction.offset;
+    final target = MazePosition(
+      s.playerPosition.x + offset.x,
+      s.playerPosition.y + offset.y,
+    );
+
+    if (target.x < 0 || target.y < 0 || target.x >= 10 || target.y >= 10) {
+      return;
+    }
+
+    final door = s.doorBetween(s.playerPosition, target);
+    if (door == DoorState.wall) return;
+
+    state = s.enterRoom(target, from: s.playerPosition);
+  }
+
+  void submitAnswer(int selectedIndex) {
+    final s = state;
+    if (s == null || s.status != MazeStatus.questionActive) return;
+
+    final q = s.activeQuestion;
+    if (q == null) return;
+
+    final correct = q.isCorrect(selectedIndex);
+    state = correct ? s.answerCorrect() : s.answerWrong();
+  }
+
+  void skipRoom() {
+    final s = state;
+    if (s == null || s.status != MazeStatus.questionActive) return;
+    state = s.skipRoom();
+  }
+
+  void dismissFunFact() {
+    final s = state;
+    if (s == null || s.status != MazeStatus.answerRevealed) return;
+    if (s.isGameOver) return;
+    state = s.dismissFunFact();
+  }
+
+  void restart() {
+    state = null;
+  }
+}
+
+final mazeStateProvider =
+    NotifierProvider<MazeStateNotifier, MazeState?>(MazeStateNotifier.new);

--- a/lib/features/maze/presentation/screens/maze_screen.dart
+++ b/lib/features/maze/presentation/screens/maze_screen.dart
@@ -1,0 +1,428 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../gameplay/domain/models/question.dart';
+import '../../../gameplay/presentation/widgets/answer_button.dart';
+import '../../../gameplay/presentation/widgets/question_card.dart';
+import '../../domain/models/maze_state.dart';
+import '../../domain/models/maze_status.dart';
+import '../providers/maze_state_provider.dart';
+import '../widgets/maze_action_panel.dart';
+import '../widgets/maze_map_widget.dart';
+
+class MazeScreen extends ConsumerStatefulWidget {
+  const MazeScreen({super.key});
+
+  @override
+  ConsumerState<MazeScreen> createState() => _MazeScreenState();
+}
+
+class _MazeScreenState extends ConsumerState<MazeScreen> {
+  bool _sheetOpen = false;
+  bool _endShown = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final mazeState = ref.watch(mazeStateProvider);
+
+    ref.listen<MazeState?>(mazeStateProvider, (prev, next) {
+      if (next == null) return;
+
+      if (next.status == MazeStatus.questionActive && !_sheetOpen) {
+        _openQuestionSheet(next);
+      }
+
+      if ((next.isComplete || next.isGameOver) && !_endShown) {
+        _endShown = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _showEndSheet(next);
+        });
+      }
+    });
+
+    if (mazeState == null) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.stoneDark,
+        title: const Text('The Maze'),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => _confirmExit(),
+        ),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 12),
+            child: Center(
+              child: Text(
+                '${mazeState.roomsVisited}/100',
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      color: AppColors.textLight.withValues(alpha: 0.6),
+                    ),
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(child: MazeMapWidget(mazeState: mazeState)),
+          MazeActionPanel(
+            mazeState: mazeState,
+            onMove: (d) =>
+                ref.read(mazeStateProvider.notifier).movePlayer(d),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _openQuestionSheet(MazeState mazeState) async {
+    _sheetOpen = true;
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      isDismissible: false,
+      enableDrag: false,
+      backgroundColor: Colors.transparent,
+      builder: (_) => _QuestionSheet(mazeState: mazeState),
+    );
+    _sheetOpen = false;
+  }
+
+  void _showEndSheet(MazeState maze) {
+    final isComplete = maze.isComplete;
+    showModalBottomSheet<void>(
+      context: context,
+      isDismissible: false,
+      enableDrag: false,
+      backgroundColor: AppColors.stoneDark,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) => _EndSheet(maze: maze, isComplete: isComplete),
+    );
+  }
+
+  void _confirmExit() {
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: AppColors.stoneDark,
+        title: const Text('Abandon Maze?',
+            style: TextStyle(color: AppColors.textLight)),
+        content: const Text(
+          'Your progress will be lost.',
+          style: TextStyle(color: AppColors.textLight),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Stay',
+                style: TextStyle(color: AppColors.torchAmber)),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              ref.read(mazeStateProvider.notifier).restart();
+              context.go('/');
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.dangerRed,
+              foregroundColor: AppColors.textLight,
+            ),
+            child: const Text('Leave'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Question bottom sheet ──────────────────────────────────────────────────
+
+class _QuestionSheet extends ConsumerStatefulWidget {
+  final MazeState mazeState;
+
+  const _QuestionSheet({required this.mazeState});
+
+  @override
+  ConsumerState<_QuestionSheet> createState() => _QuestionSheetState();
+}
+
+class _QuestionSheetState extends ConsumerState<_QuestionSheet> {
+  int? _selectedIndex;
+  bool _locked = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final mazeState = ref.watch(mazeStateProvider) ?? widget.mazeState;
+    final q = mazeState.activeQuestion ?? widget.mazeState.activeQuestion;
+    if (q == null) return const SizedBox.shrink();
+
+    final isRevealed = mazeState.status == MazeStatus.answerRevealed;
+
+    return Padding(
+      padding:
+          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: Container(
+        decoration: const BoxDecoration(
+          color: AppColors.stoneDark,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+        ),
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: AppColors.stoneMid,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(height: 12),
+              QuestionCard(question: q, onArticleTap: null),
+              const SizedBox(height: 12),
+              ...List.generate(q.options.length, (i) {
+                AnswerState state = AnswerState.idle;
+                if (isRevealed) {
+                  if (i == q.correctIndex) {
+                    state = AnswerState.correct;
+                  } else if (i == _selectedIndex) {
+                    state = AnswerState.wrong;
+                  }
+                }
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: AnswerButton(
+                    label: String.fromCharCode(65 + i),
+                    text: q.options[i],
+                    state: state,
+                    onTap: _locked ? null : () => _handleAnswer(i, q),
+                  ),
+                );
+              }),
+              if (isRevealed) ...[
+                const SizedBox(height: 8),
+                _FunFactTile(
+                  funFact: q.funFact,
+                  correct: mazeState.lastAnswerCorrect ?? false,
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      if (mazeState.isGameOver) {
+                        // Don't dismiss — let the end sheet handle it.
+                        Navigator.of(context).pop();
+                      } else {
+                        ref
+                            .read(mazeStateProvider.notifier)
+                            .dismissFunFact();
+                        Navigator.of(context).pop();
+                      }
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.torchAmber,
+                      foregroundColor: AppColors.textDark,
+                    ),
+                    child: Text(
+                        mazeState.isGameOver ? 'See Results' : 'Onward!'),
+                  ),
+                ),
+              ] else ...[
+                const SizedBox(height: 4),
+                TextButton(
+                  onPressed: _locked
+                      ? null
+                      : () {
+                          ref.read(mazeStateProvider.notifier).skipRoom();
+                          Navigator.of(context).pop();
+                        },
+                  child: const Text(
+                    'Skip this room',
+                    style: TextStyle(color: AppColors.stoneMid, fontSize: 13),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleAnswer(int index, QuizQuestion q) async {
+    if (_locked) return;
+    setState(() {
+      _selectedIndex = index;
+      _locked = true;
+    });
+    HapticFeedback.mediumImpact();
+    ref.read(mazeStateProvider.notifier).submitAnswer(index);
+  }
+}
+
+// ── End sheet ──────────────────────────────────────────────────────────────
+
+class _EndSheet extends ConsumerWidget {
+  final MazeState maze;
+  final bool isComplete;
+
+  const _EndSheet({required this.maze, required this.isComplete});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tt = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            isComplete
+                ? Icons.castle
+                : Icons.sentiment_very_dissatisfied,
+            size: 56,
+            color: isComplete ? AppColors.torchGold : AppColors.dangerRed,
+          )
+              .animate()
+              .scale(
+                begin: const Offset(0.3, 0.3),
+                end: const Offset(1, 1),
+                duration: 500.ms,
+                curve: Curves.elasticOut,
+              ),
+          const SizedBox(height: 16),
+          Text(
+            isComplete ? 'Throne Room Reached!' : 'The Maze Claims You…',
+            style: tt.displaySmall?.copyWith(
+              color:
+                  isComplete ? AppColors.torchGold : AppColors.dangerRed,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          _StatLine(label: 'Rooms Visited', value: '${maze.roomsVisited}'),
+          const SizedBox(height: 4),
+          _StatLine(
+            label: 'Questions Correct',
+            value: '${maze.correctCount} / ${maze.questionsAnswered}',
+          ),
+          const SizedBox(height: 4),
+          _StatLine(
+            label: 'Lives Remaining',
+            value: '${maze.lives} / 3',
+            valueColor:
+                maze.lives > 0 ? AppColors.dangerRed : AppColors.stoneMid,
+          ),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                ref.read(mazeStateProvider.notifier).restart();
+                context.go('/');
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: isComplete
+                    ? AppColors.torchGold
+                    : AppColors.torchAmber,
+                foregroundColor: AppColors.textDark,
+                padding: const EdgeInsets.symmetric(vertical: 16),
+              ),
+              child: Text(
+                'Back to Start',
+                style: tt.displaySmall
+                    ?.copyWith(color: AppColors.textDark, fontSize: 17),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatLine extends StatelessWidget {
+  final String label;
+  final String value;
+  final Color? valueColor;
+
+  const _StatLine({
+    required this.label,
+    required this.value,
+    this.valueColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(label,
+            style: tt.bodySmall?.copyWith(color: AppColors.textLight)),
+        Text(
+          value,
+          style: tt.labelMedium?.copyWith(
+            color: valueColor ?? AppColors.torchAmber,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Fun fact tile ──────────────────────────────────────────────────────────
+
+class _FunFactTile extends StatelessWidget {
+  final String funFact;
+  final bool correct;
+
+  const _FunFactTile({required this.funFact, required this.correct});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = correct ? AppColors.torchGold : AppColors.dangerRed;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            correct ? '✓ Correct!' : '✗ Wrong',
+            style: TextStyle(
+                color: color, fontWeight: FontWeight.bold, fontSize: 13),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            funFact,
+            style: const TextStyle(color: AppColors.textLight, fontSize: 13),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/maze/presentation/screens/maze_settings_screen.dart
+++ b/lib/features/maze/presentation/screens/maze_settings_screen.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../gameplay/data/topic_registry.dart';
+import '../../../gameplay/domain/models/quiz_config.dart';
+import '../../../gameplay/presentation/providers/quiz_config_provider.dart';
+import '../providers/maze_state_provider.dart';
+
+const _kDifficultyLabels = [
+  'Very Easy',
+  'Easy',
+  'Medium',
+  'Hard',
+  'Very Hard',
+];
+
+Color _biasColor(int bias) => switch (bias) {
+      1 || 2 => AppColors.torchGold,
+      4 || 5 => AppColors.dangerRed,
+      _ => AppColors.torchAmber,
+    };
+
+class MazeSettingsScreen extends ConsumerStatefulWidget {
+  const MazeSettingsScreen({super.key});
+
+  @override
+  ConsumerState<MazeSettingsScreen> createState() => _MazeSettingsScreenState();
+}
+
+class _MazeSettingsScreenState extends ConsumerState<MazeSettingsScreen> {
+  late int _difficultyBias;
+  bool _starting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _difficultyBias = ref.read(quizConfigProvider).difficultyBias;
+  }
+
+  int get _topicCount =>
+      ref.watch(quizConfigProvider).selectedTopicIds.length;
+
+  bool get _allTopicsSelected => _topicCount == allTopicIds.length;
+
+  Future<void> _enterMaze() async {
+    if (_starting) return;
+    setState(() => _starting = true);
+
+    final currentTopics = ref.read(quizConfigProvider).selectedTopicIds;
+    final topicIds =
+        currentTopics.isEmpty ? Set<String>.from(allTopicIds) : currentTopics;
+
+    final config = QuizConfig(
+      selectedTopicIds: topicIds,
+      questionCount: 10,
+      difficultyBias: _difficultyBias,
+    );
+    ref.read(quizConfigProvider.notifier).setConfig(config);
+    await ref.read(mazeStateProvider.notifier).startMaze(config);
+    if (mounted) context.go('/maze');
+  }
+
+  void _openTopics() {
+    final currentConfig = ref.read(quizConfigProvider);
+    ref.read(quizConfigProvider.notifier).setConfig(
+          currentConfig.copyWith(difficultyBias: _difficultyBias),
+        );
+    context.push('/topics', extra: {'fromSettings': true});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    final difficultyLabel = _kDifficultyLabels[_difficultyBias - 1];
+    final difficultyColor = _biasColor(_difficultyBias);
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.stoneDark,
+        title: const Text('Maze Mode'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 520),
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(20, 20, 20, 8),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Mode description banner
+                        Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 14, vertical: 12),
+                          decoration: BoxDecoration(
+                            color: AppColors.stone.withValues(alpha: 0.4),
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(color: AppColors.stoneMid),
+                          ),
+                          child: Text(
+                            '10×10 maze · fog of war · answer to unlock doors · find the Throne Room',
+                            style: tt.bodySmall?.copyWith(
+                              color: AppColors.textLight.withValues(alpha: 0.7),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 28),
+
+                        // Difficulty
+                        Text('Difficulty',
+                            style: tt.labelLarge
+                                ?.copyWith(color: AppColors.parchment)),
+                        const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            const Text('🕯️',
+                                style: TextStyle(fontSize: 16)),
+                            Expanded(
+                              child: Slider(
+                                value: _difficultyBias.toDouble(),
+                                min: 1,
+                                max: 5,
+                                divisions: 4,
+                                activeColor: difficultyColor,
+                                inactiveColor:
+                                    AppColors.stoneMid.withValues(alpha: 0.5),
+                                onChanged: (v) =>
+                                    setState(() => _difficultyBias = v.round()),
+                              ),
+                            ),
+                            const Text('⚔️',
+                                style: TextStyle(fontSize: 16)),
+                          ],
+                        ),
+                        Center(
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 14, vertical: 4),
+                            decoration: BoxDecoration(
+                              color: difficultyColor.withValues(alpha: 0.15),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(color: difficultyColor),
+                            ),
+                            child: Text(
+                              difficultyLabel,
+                              style: tt.labelMedium?.copyWith(
+                                  color: difficultyColor,
+                                  fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 28),
+
+                        // Topics
+                        Text('Topics',
+                            style: tt.labelLarge
+                                ?.copyWith(color: AppColors.parchment)),
+                        const SizedBox(height: 8),
+                        Material(
+                          color: AppColors.stone,
+                          borderRadius: BorderRadius.circular(8),
+                          child: InkWell(
+                            borderRadius: BorderRadius.circular(8),
+                            onTap: _openTopics,
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 14),
+                              child: Row(
+                                children: [
+                                  const Icon(Icons.tune,
+                                      color: AppColors.torchAmber, size: 20),
+                                  const SizedBox(width: 12),
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          _allTopicsSelected
+                                              ? 'All topics'
+                                              : '$_topicCount of ${allTopicIds.length} topics',
+                                          style: const TextStyle(
+                                              color: AppColors.textLight),
+                                        ),
+                                        Text(
+                                          'Tap to customise',
+                                          style: tt.bodySmall?.copyWith(
+                                              color: AppColors.textLight
+                                                  .withValues(alpha: 0.5)),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                  const Icon(Icons.chevron_right,
+                                      color: AppColors.stoneMid),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 20),
+                      ],
+                    ),
+                  ),
+                ),
+
+                // Bottom action bar
+                Container(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                  decoration: const BoxDecoration(
+                    color: AppColors.stoneDark,
+                    border: Border(top: BorderSide(color: AppColors.stoneMid)),
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: () => context.pop(),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: AppColors.textLight,
+                            side: const BorderSide(color: AppColors.stoneMid),
+                            padding:
+                                const EdgeInsets.symmetric(vertical: 14),
+                          ),
+                          child: const Text('Back'),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        flex: 2,
+                        child: ElevatedButton.icon(
+                          onPressed: _starting ? null : _enterMaze,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: AppColors.torchAmber,
+                            foregroundColor: AppColors.textDark,
+                            padding: const EdgeInsets.symmetric(vertical: 14),
+                          ),
+                          icon: _starting
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      color: AppColors.textDark))
+                              : const Icon(Icons.explore),
+                          label: Text(
+                            _starting ? 'Generating…' : 'Enter the Maze',
+                            style: const TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/maze/presentation/widgets/maze_action_panel.dart
+++ b/lib/features/maze/presentation/widgets/maze_action_panel.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../domain/models/door_state.dart';
+import '../../domain/models/maze_position.dart';
+import '../../domain/models/maze_state.dart';
+import '../../domain/models/maze_status.dart';
+import '../providers/maze_state_provider.dart';
+
+class MazeActionPanel extends StatelessWidget {
+  final MazeState mazeState;
+  final void Function(Direction) onMove;
+
+  const MazeActionPanel({
+    super.key,
+    required this.mazeState,
+    required this.onMove,
+  });
+
+  bool _canMove(Direction d) {
+    final (dx, dy) = switch (d) {
+      Direction.north => (0, -1),
+      Direction.south => (0, 1),
+      Direction.west => (-1, 0),
+      Direction.east => (1, 0),
+    };
+    final pos = mazeState.playerPosition;
+    final nx = pos.x + dx;
+    final ny = pos.y + dy;
+    if (nx < 0 || ny < 0 || nx >= 10 || ny >= 10) return false;
+    final target = MazePosition(nx, ny);
+    return mazeState.doorBetween(pos, target) != DoorState.wall;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    final isNavigating = mazeState.status == MazeStatus.navigating;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+      decoration: const BoxDecoration(
+        color: AppColors.stoneDark,
+        border: Border(top: BorderSide(color: AppColors.stoneMid)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Lives row
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text('Lives  ', style: tt.labelMedium),
+              ...List.generate(
+                3,
+                (i) => Icon(
+                  Icons.favorite,
+                  size: 20,
+                  color: i < mazeState.lives
+                      ? AppColors.dangerRed
+                      : AppColors.stoneMid,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+
+          // Direction arrows
+          Column(
+            children: [
+              _ArrowButton(
+                icon: Icons.keyboard_arrow_up,
+                enabled: isNavigating && _canMove(Direction.north),
+                onTap: () => onMove(Direction.north),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _ArrowButton(
+                    icon: Icons.keyboard_arrow_left,
+                    enabled: isNavigating && _canMove(Direction.west),
+                    onTap: () => onMove(Direction.west),
+                  ),
+                  const SizedBox(
+                    width: 48,
+                    height: 48,
+                    child: Center(
+                      child: Icon(Icons.explore_outlined,
+                          color: AppColors.stoneMid, size: 20),
+                    ),
+                  ),
+                  _ArrowButton(
+                    icon: Icons.keyboard_arrow_right,
+                    enabled: isNavigating && _canMove(Direction.east),
+                    onTap: () => onMove(Direction.east),
+                  ),
+                ],
+              ),
+              _ArrowButton(
+                icon: Icons.keyboard_arrow_down,
+                enabled: isNavigating && _canMove(Direction.south),
+                onTap: () => onMove(Direction.south),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ArrowButton extends StatelessWidget {
+  final IconData icon;
+  final bool enabled;
+  final VoidCallback onTap;
+
+  const _ArrowButton({
+    required this.icon,
+    required this.enabled,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 48,
+      height: 48,
+      child: Material(
+        color: enabled
+            ? AppColors.stone
+            : AppColors.background.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(8),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(8),
+          onTap: enabled ? onTap : null,
+          child: Icon(
+            icon,
+            color: enabled ? AppColors.torchAmber : AppColors.stoneMid,
+            size: 28,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/maze/presentation/widgets/maze_cell_widget.dart
+++ b/lib/features/maze/presentation/widgets/maze_cell_widget.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../domain/models/door_state.dart';
+import '../../domain/models/maze_position.dart';
+import '../../domain/models/maze_room.dart';
+import '../../domain/models/maze_state.dart';
+import '../../domain/models/room_status.dart';
+
+class MazeCellWidget extends StatelessWidget {
+  final MazeRoom room;
+  final MazeState mazeState;
+  final bool isPlayer;
+  final bool throneDiscovered;
+
+  const MazeCellWidget({
+    super.key,
+    required this.room,
+    required this.mazeState,
+    required this.isPlayer,
+    required this.throneDiscovered,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final status = room.status;
+    final pos = room.position;
+
+    if (status == RoomStatus.hidden) {
+      return _HiddenCell(pos: pos, mazeState: mazeState);
+    }
+
+    return _VisibleCell(
+      room: room,
+      mazeState: mazeState,
+      isPlayer: isPlayer,
+      throneDiscovered: throneDiscovered,
+    );
+  }
+}
+
+class _HiddenCell extends StatelessWidget {
+  final MazePosition pos;
+  final MazeState mazeState;
+
+  const _HiddenCell({required this.pos, required this.mazeState});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.background,
+        border: _borderFor(pos, mazeState, hidden: true),
+      ),
+    );
+  }
+}
+
+class _VisibleCell extends StatelessWidget {
+  final MazeRoom room;
+  final MazeState mazeState;
+  final bool isPlayer;
+  final bool throneDiscovered;
+
+  const _VisibleCell({
+    required this.room,
+    required this.mazeState,
+    required this.isPlayer,
+    required this.throneDiscovered,
+  });
+
+  Color get _bgColor {
+    if (room.isThroneRoom && throneDiscovered) {
+      return AppColors.torchGold.withValues(alpha: 0.25);
+    }
+    return switch (room.status) {
+      RoomStatus.answered => AppColors.torchGold.withValues(alpha: 0.2),
+      RoomStatus.skipped => AppColors.torchAmber.withValues(alpha: 0.1),
+      RoomStatus.visible => AppColors.stone.withValues(alpha: 0.4),
+      _ => AppColors.stone,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget cell = Container(
+      decoration: BoxDecoration(
+        color: _bgColor,
+        border: _borderFor(room.position, mazeState),
+      ),
+      child: Center(child: _icon),
+    );
+
+    if (room.status == RoomStatus.answered) {
+      cell = cell
+          .animate(key: ValueKey('answered_${room.position}'))
+          .shimmer(duration: 800.ms, color: AppColors.torchGold);
+    } else if (room.status == RoomStatus.visible) {
+      cell = cell
+          .animate(key: ValueKey('reveal_${room.position}'))
+          .fadeIn(duration: 200.ms)
+          .scale(begin: const Offset(0.85, 0.85), end: const Offset(1, 1));
+    }
+
+    return cell;
+  }
+
+  Widget? get _icon {
+    if (isPlayer) {
+      return const Icon(Icons.person, color: AppColors.parchment, size: 14);
+    }
+    if (room.isThroneRoom && throneDiscovered) {
+      return const Icon(Icons.castle, color: AppColors.torchGold, size: 14)
+          .animate(onPlay: (c) => c.repeat(reverse: true))
+          .custom(
+            duration: 1200.ms,
+            builder: (_, v, child) =>
+                Opacity(opacity: 0.6 + v * 0.4, child: child),
+          );
+    }
+    return switch (room.status) {
+      RoomStatus.answered =>
+        const Icon(Icons.check, color: AppColors.torchGold, size: 10),
+      RoomStatus.skipped =>
+        const Icon(Icons.fast_forward, color: AppColors.torchAmber, size: 10),
+      _ => null,
+    };
+  }
+}
+
+Border _borderFor(
+  MazePosition pos,
+  MazeState mazeState, {
+  bool hidden = false,
+}) {
+  if (hidden) {
+    return Border.all(
+        color: AppColors.background.withValues(alpha: 0.3), width: 0.5);
+  }
+
+  BorderSide wall =
+      const BorderSide(color: AppColors.stoneMid, width: 1.5);
+  BorderSide open =
+      BorderSide(color: AppColors.stone.withValues(alpha: 0.3), width: 0.5);
+  BorderSide wallHeavy =
+      const BorderSide(color: AppColors.stoneDark, width: 2.5);
+
+  BorderSide sideFor(MazePosition neighbour) {
+    if (neighbour.x < 0 ||
+        neighbour.y < 0 ||
+        neighbour.x >= 10 ||
+        neighbour.y >= 10) {
+      return wallHeavy;
+    }
+    final door = mazeState.doorBetween(pos, neighbour);
+    return switch (door) {
+      DoorState.wall => wall,
+      _ => open,
+    };
+  }
+
+  return Border(
+    top: sideFor(MazePosition(pos.x, pos.y - 1)),
+    bottom: sideFor(MazePosition(pos.x, pos.y + 1)),
+    left: sideFor(MazePosition(pos.x - 1, pos.y)),
+    right: sideFor(MazePosition(pos.x + 1, pos.y)),
+  );
+}

--- a/lib/features/maze/presentation/widgets/maze_map_widget.dart
+++ b/lib/features/maze/presentation/widgets/maze_map_widget.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/models/maze_state.dart';
+import 'maze_cell_widget.dart';
+
+class MazeMapWidget extends StatelessWidget {
+  final MazeState mazeState;
+
+  const MazeMapWidget({super.key, required this.mazeState});
+
+  @override
+  Widget build(BuildContext context) {
+    const cellSize = 32.0;
+    const gridSize = cellSize * 10;
+
+    return InteractiveViewer(
+      minScale: 0.5,
+      maxScale: 3.0,
+      child: Center(
+        child: SizedBox(
+          width: gridSize,
+          height: gridSize,
+          child: GridView.builder(
+            physics: const NeverScrollableScrollPhysics(),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 10,
+              childAspectRatio: 1,
+            ),
+            itemCount: 100,
+            itemBuilder: (context, index) {
+              final x = index % 10;
+              final y = index ~/ 10;
+              final room = mazeState.grid[y][x];
+              final isPlayer = mazeState.playerPosition.x == x &&
+                  mazeState.playerPosition.y == y;
+              return MazeCellWidget(
+                room: room,
+                mazeState: mazeState,
+                isPlayer: isPlayer,
+                throneDiscovered: mazeState.throneDiscovered,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/start/presentation/screens/start_screen.dart
+++ b/lib/features/start/presentation/screens/start_screen.dart
@@ -114,6 +114,28 @@ class StartScreen extends ConsumerWidget {
 
                     const SizedBox(height: 12),
 
+                    // Maze Mode button
+                    SizedBox(
+                      width: double.infinity,
+                      child: OutlinedButton.icon(
+                        onPressed: () => context.push('/maze-settings'),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: AppColors.torchGold,
+                          side: const BorderSide(
+                              color: AppColors.torchGold, width: 1.5),
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(6)),
+                        ),
+                        icon: const Icon(Icons.explore, size: 18),
+                        label: Text('Maze Mode',
+                            style: textTheme.labelLarge?.copyWith(
+                                color: AppColors.torchGold, fontSize: 16)),
+                      ),
+                    ).animate().fadeIn(duration: 500.ms, delay: 650.ms),
+
+                    const SizedBox(height: 12),
+
                     // Select Mode button
                     SizedBox(
                       width: double.infinity,

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Features
-- (none)
+- **Maze Mode** — a new 10×10 grid game mode inspired by the original Mind Maze; navigate a procedurally generated perfect maze with fog-of-war reveal, answer-locked doors, free backtracking, and a hidden Throne Room win condition; accessible via a new "Maze Mode" tile on the Start screen (#40)
 
 ### Fixes
 - (none)

--- a/test/features/maze/data/maze_generator_test.dart
+++ b/test/features/maze/data/maze_generator_test.dart
@@ -1,0 +1,197 @@
+import 'dart:collection';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mind_maze/features/gameplay/domain/models/quiz_config.dart';
+import 'package:mind_maze/features/maze/data/maze_generator.dart';
+import 'package:mind_maze/features/maze/domain/models/door_state.dart';
+import 'package:mind_maze/features/maze/domain/models/maze_position.dart';
+import 'package:mind_maze/features/maze/domain/models/maze_status.dart';
+import 'package:mind_maze/features/maze/domain/models/room_status.dart';
+
+const _config = QuizConfig(
+  selectedTopicIds: {'coffee'},
+  questionCount: 10,
+);
+
+void main() {
+  late final maze = MazeGenerator.generate(
+    config: _config,
+    questionPool: [],
+    seed: 42,
+  );
+
+  group('MazeGenerator — structure', () {
+    test('grid is 10×10', () {
+      expect(maze.grid.length, equals(10));
+      for (final row in maze.grid) {
+        expect(row.length, equals(10));
+      }
+    });
+
+    test('exactly 99 connections (spanning tree: n-1 for n=100)', () {
+      expect(maze.connections.length, equals(99));
+    });
+
+    test('all connection values are locked at generation time', () {
+      for (final v in maze.connections.values) {
+        expect(v, equals(DoorState.locked));
+      }
+    });
+
+    test('exactly one throne room', () {
+      final throneCount = maze.grid
+          .expand((row) => row)
+          .where((r) => r.isThroneRoom)
+          .length;
+      expect(throneCount, equals(1));
+    });
+
+    test('throne room has no question', () {
+      final throne =
+          maze.grid.expand((row) => row).firstWhere((r) => r.isThroneRoom);
+      expect(throne.questionId, isNull);
+    });
+
+    test('start cell (0,0) has no question', () {
+      expect(maze.grid[0][0].questionId, isNull);
+    });
+
+    test('start cell is visited', () {
+      expect(maze.grid[0][0].status, equals(RoomStatus.visited));
+    });
+
+    test('initial status is navigating', () {
+      expect(maze.status, equals(MazeStatus.navigating));
+    });
+
+    test('initial lives are 3', () {
+      expect(maze.lives, equals(3));
+    });
+
+    test('player starts at (0,0)', () {
+      expect(maze.playerPosition, equals(const MazePosition(0, 0)));
+    });
+  });
+
+  group('MazeGenerator — connectivity', () {
+    test('all 100 cells reachable from (0,0) via BFS', () {
+      final visited = <MazePosition>{};
+      final queue = Queue<MazePosition>();
+      queue.add(const MazePosition(0, 0));
+      visited.add(const MazePosition(0, 0));
+
+      while (queue.isNotEmpty) {
+        final cur = queue.removeFirst();
+        const offsets = [
+          MazePosition(0, -1),
+          MazePosition(0, 1),
+          MazePosition(-1, 0),
+          MazePosition(1, 0),
+        ];
+        for (final d in offsets) {
+          final nx = cur.x + d.x;
+          final ny = cur.y + d.y;
+          if (nx < 0 || ny < 0 || nx >= 10 || ny >= 10) continue;
+          final neighbour = MazePosition(nx, ny);
+          if (visited.contains(neighbour)) continue;
+          if (maze.connections.containsKey(
+            maze.connections.keys.firstWhere(
+              (k) => k == _key(cur, neighbour),
+              orElse: () => '',
+            ),
+          )) {
+            visited.add(neighbour);
+            queue.add(neighbour);
+          }
+        }
+      }
+
+      expect(visited.length, equals(100));
+    });
+
+    test('all 100 cells reachable using doorBetween', () {
+      final visited = <MazePosition>{};
+      final queue = Queue<MazePosition>();
+      queue.add(const MazePosition(0, 0));
+      visited.add(const MazePosition(0, 0));
+
+      while (queue.isNotEmpty) {
+        final cur = queue.removeFirst();
+        const offsets = [
+          MazePosition(0, -1),
+          MazePosition(0, 1),
+          MazePosition(-1, 0),
+          MazePosition(1, 0),
+        ];
+        for (final d in offsets) {
+          final nx = cur.x + d.x;
+          final ny = cur.y + d.y;
+          if (nx < 0 || ny < 0 || nx >= 10 || ny >= 10) continue;
+          final neighbour = MazePosition(nx, ny);
+          if (visited.contains(neighbour)) continue;
+          if (maze.doorBetween(cur, neighbour) != DoorState.wall) {
+            visited.add(neighbour);
+            queue.add(neighbour);
+          }
+        }
+      }
+
+      expect(visited.length, equals(100));
+    });
+  });
+
+  group('MazeGenerator — throne placement', () {
+    test('throne is not at (0,0)', () {
+      expect(maze.thronePosition, isNot(equals(const MazePosition(0, 0))));
+    });
+
+    test('throne grid cell matches thronePosition', () {
+      final tp = maze.thronePosition;
+      expect(maze.grid[tp.y][tp.x].isThroneRoom, isTrue);
+    });
+
+    test('different seeds produce different mazes', () {
+      final m1 = MazeGenerator.generate(
+        config: _config,
+        questionPool: [],
+        seed: 1,
+      );
+      final m2 = MazeGenerator.generate(
+        config: _config,
+        questionPool: [],
+        seed: 2,
+      );
+      // Very unlikely to be identical
+      expect(m1.thronePosition == m2.thronePosition, isFalse);
+    });
+  });
+
+  group('MazeGenerator — fog of war', () {
+    test('neighbours of start are visible', () {
+      const offsets = [
+        MazePosition(0, -1),
+        MazePosition(0, 1),
+        MazePosition(-1, 0),
+        MazePosition(1, 0),
+      ];
+      for (final d in offsets) {
+        final nx = d.x;
+        final ny = d.y;
+        if (nx < 0 || ny < 0 || nx >= 10 || ny >= 10) continue;
+        final room = maze.grid[ny][nx];
+        expect(room.status, equals(RoomStatus.visible));
+      }
+    });
+
+    test('cells further away are hidden', () {
+      // (5,5) should be hidden in an unstarted maze
+      expect(maze.grid[5][5].status, equals(RoomStatus.hidden));
+    });
+  });
+}
+
+String _key(MazePosition a, MazePosition b) {
+  final first = (a.y < b.y || (a.y == b.y && a.x < b.x)) ? a : b;
+  final second = first == a ? b : a;
+  return '${first.y},${first.x}-${second.y},${second.x}';
+}

--- a/test/features/maze/domain/maze_state_test.dart
+++ b/test/features/maze/domain/maze_state_test.dart
@@ -1,0 +1,222 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mind_maze/features/gameplay/domain/models/quiz_config.dart';
+import 'package:mind_maze/features/maze/domain/models/door_state.dart';
+import 'package:mind_maze/features/maze/domain/models/maze_position.dart';
+import 'package:mind_maze/features/maze/domain/models/maze_room.dart';
+import 'package:mind_maze/features/maze/domain/models/maze_state.dart';
+import 'package:mind_maze/features/maze/domain/models/maze_status.dart';
+import 'package:mind_maze/features/maze/domain/models/room_status.dart';
+
+const _dummyConfig = QuizConfig(
+  selectedTopicIds: {'coffee'},
+  questionCount: 10,
+);
+
+MazeState _tenByTenState({
+  MazePosition player = const MazePosition(0, 0),
+  MazePosition? entryFrom,
+  int lives = 3,
+  MazeStatus status = MazeStatus.navigating,
+  Map<String, DoorState>? connections,
+}) {
+  final grid = List.generate(
+    10,
+    (y) => List.generate(
+      10,
+      (x) => MazeRoom(
+        position: MazePosition(x, y),
+        questionId: (x == 0 && y == 0) ? null : 'q_${y}_$x',
+        isThroneRoom: x == 9 && y == 9,
+        status: (x == 0 && y == 0) ? RoomStatus.visited : RoomStatus.hidden,
+      ),
+      growable: false,
+    ),
+    growable: false,
+  );
+
+  return MazeState(
+    grid: grid,
+    connections: connections ?? {},
+    playerPosition: player,
+    entryFrom: entryFrom,
+    thronePosition: const MazePosition(9, 9),
+    questions: {},
+    lives: lives,
+    status: status,
+    config: _dummyConfig,
+  );
+}
+
+void main() {
+  group('connectionKey', () {
+    test('is order-independent', () {
+      final a = const MazePosition(1, 0);
+      final b = const MazePosition(0, 0);
+      expect(connectionKey(a, b), equals(connectionKey(b, a)));
+    });
+
+    test('smaller y,x comes first', () {
+      final key =
+          connectionKey(const MazePosition(1, 0), const MazePosition(0, 0));
+      expect(key, equals('0,0-0,1'));
+    });
+  });
+
+  group('MazePosition', () {
+    test('equality', () {
+      expect(const MazePosition(2, 3), equals(const MazePosition(2, 3)));
+      expect(
+        const MazePosition(1, 2),
+        isNot(equals(const MazePosition(2, 1))),
+      );
+    });
+  });
+
+  group('MazeState.copyWith', () {
+    test('clearActiveQuestion nulls it', () {
+      final s = _tenByTenState().copyWith(clearActiveQuestion: true);
+      expect(s.activeQuestion, isNull);
+    });
+
+    test('clearLastAnswer nulls it', () {
+      final s = _tenByTenState(status: MazeStatus.answerRevealed)
+          .copyWith(lives: 2, lastAnswerCorrect: false)
+          .copyWith(clearLastAnswer: true);
+      expect(s.lastAnswerCorrect, isNull);
+    });
+  });
+
+  group('MazeState lives', () {
+    test('answerWrong decrements life', () {
+      final s =
+          _tenByTenState(status: MazeStatus.questionActive, lives: 3)
+              .answerWrong();
+      expect(s.lives, equals(2));
+      expect(s.status, equals(MazeStatus.answerRevealed));
+    });
+
+    test('answerWrong triggers gameOver when lives reach 0', () {
+      final s =
+          _tenByTenState(status: MazeStatus.questionActive, lives: 1)
+              .answerWrong();
+      expect(s.lives, equals(0));
+      expect(s.status, equals(MazeStatus.gameOver));
+      expect(s.isGameOver, isTrue);
+    });
+
+    test('answerCorrect does not change lives', () {
+      final base = _tenByTenState(
+        player: const MazePosition(1, 0),
+        entryFrom: const MazePosition(0, 0),
+        lives: 2,
+        status: MazeStatus.questionActive,
+        connections: {
+          connectionKey(
+            const MazePosition(0, 0),
+            const MazePosition(1, 0),
+          ): DoorState.locked,
+        },
+      );
+      final s = base.answerCorrect();
+      expect(s.lives, equals(2));
+      expect(s.status, equals(MazeStatus.answerRevealed));
+      expect(s.lastAnswerCorrect, isTrue);
+    });
+  });
+
+  group('MazeState.skipRoom', () {
+    test('sets room to skipped and status to navigating', () {
+      final base = _tenByTenState(
+        player: const MazePosition(1, 0),
+        entryFrom: const MazePosition(0, 0),
+        status: MazeStatus.questionActive,
+        connections: {
+          connectionKey(
+            const MazePosition(0, 0),
+            const MazePosition(1, 0),
+          ): DoorState.locked,
+        },
+      );
+      final s = base.skipRoom();
+      expect(s.status, equals(MazeStatus.navigating));
+      expect(
+        s.roomAt(const MazePosition(1, 0)).status,
+        equals(RoomStatus.skipped),
+      );
+    });
+  });
+
+  group('MazeState.enterRoom', () {
+    test('throne room triggers complete', () {
+      final base = _tenByTenState(
+        player: const MazePosition(8, 9),
+        status: MazeStatus.navigating,
+      );
+      final s = base.enterRoom(
+        const MazePosition(9, 9),
+        from: const MazePosition(8, 9),
+      );
+      expect(s.status, equals(MazeStatus.complete));
+      expect(s.isComplete, isTrue);
+    });
+
+    test('room with no question goes to navigating', () {
+      final noQGrid = List.generate(
+        10,
+        (y) => List.generate(
+          10,
+          (x) => MazeRoom(
+            position: MazePosition(x, y),
+            questionId: null,
+            isThroneRoom: x == 9 && y == 9,
+            status:
+                (x == 0 && y == 0) ? RoomStatus.visited : RoomStatus.hidden,
+          ),
+          growable: false,
+        ),
+        growable: false,
+      );
+      final s = MazeState(
+        grid: noQGrid,
+        connections: {},
+        playerPosition: const MazePosition(0, 0),
+        thronePosition: const MazePosition(9, 9),
+        questions: {},
+        lives: 3,
+        status: MazeStatus.navigating,
+        config: _dummyConfig,
+      ).enterRoom(
+        const MazePosition(1, 0),
+        from: const MazePosition(0, 0),
+      );
+      expect(s.status, equals(MazeStatus.navigating));
+    });
+  });
+
+  group('MazeState.dismissFunFact', () {
+    test('transitions answerRevealed → navigating', () {
+      final s = _tenByTenState(status: MazeStatus.answerRevealed)
+          .dismissFunFact();
+      expect(s.status, equals(MazeStatus.navigating));
+      expect(s.activeQuestion, isNull);
+    });
+  });
+
+  group('MazeState metrics', () {
+    test('correctCount counts answered rooms', () {
+      final base = _tenByTenState(
+        player: const MazePosition(1, 0),
+        entryFrom: const MazePosition(0, 0),
+        status: MazeStatus.questionActive,
+        connections: {
+          connectionKey(
+            const MazePosition(0, 0),
+            const MazePosition(1, 0),
+          ): DoorState.locked,
+        },
+      );
+      final answered = base.answerCorrect();
+      expect(answered.correctCount, equals(1));
+    });
+  });
+}


### PR DESCRIPTION
Closes #40

Implements the core Maze Mode game as specified in the plan PR #115.

## What's in this PR

| Layer | Files |
|-------|-------|
| Domain models | `MazePosition`, `DoorState`, `RoomStatus`, `MazeRoom`, `MazeStatus`, `MazeState` — pure Dart, immutable, `copyWith` |
| Maze generation | `MazeGenerator.generate()` — recursive backtracker DFS, BFS throne placement, fog-of-war initialisation |
| State provider | `MazeStateNotifier` — `startMaze`, `movePlayer`, `submitAnswer`, `skipRoom`, `dismissFunFact`, `restart` |
| Settings screen | `MazeSettingsScreen` — difficulty slider + topic picker + "Enter the Maze" CTA |
| Map widget | `MazeMapWidget` + `MazeCellWidget` — 10×10 fog-of-war grid with per-cell status styling |
| Action panel | `MazeActionPanel` — N/S/E/W direction arrows, lives display, disabled when wall blocks |
| Main screen | `MazeScreen` — composes map + panel; listens for `questionActive` to open question sheet; shows end sheet on complete/game over |
| Routing | `/maze-settings` + `/maze` added to `app.dart` |
| Entry point | "Maze Mode" tile (gold, `Icons.explore`) added to `StartScreen` between Quick Play and Select Mode |
| Tests | 30 unit tests — 16 generator tests (connectivity BFS, 99 connections, throne placement, fog) + 14 domain tests (state transitions, lives, skip, metrics) |

## Key design decisions followed from plan
- **Fully additive** — existing standard/endless modes completely untouched
- **Perfect maze** — DFS spanning tree guarantees exactly one path between any two cells (99 edges for 100 cells)
- **Throne Room at max BFS distance** — player must traverse most of the maze to win
- **Fog of war derived at render time** from `RoomStatus` — not stored separately
- **XP system excluded** per owner direction

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 129/129 pass (30 new maze tests)
- [ ] Manual: Start → Maze Mode → pick topic → Enter the Maze
- [ ] Manual: Fog of war visible; only start + neighbours shown on load
- [ ] Manual: Move N/S/E/W — walls block invalid directions (arrows disabled)
- [ ] Manual: Enter room → question sheet appears
- [ ] Manual: Answer correctly → cell turns gold, door opens
- [ ] Manual: Answer wrong → life lost; can continue or skip
- [ ] Manual: Skip → cell muted amber
- [ ] Manual: Backtrack through visited rooms freely
- [ ] Manual: Reach Throne Room → completion sheet
- [ ] Manual: Lives reach 0 → game over sheet

https://claude.ai/code/session_01JRpjnD2P2jA4ywaJoxGoCz